### PR TITLE
Added `apexCode` as a parameter for execute Anonymous

### DIFF
--- a/packages/apex-node/src/commands/apexExecute.ts
+++ b/packages/apex-node/src/commands/apexExecute.ts
@@ -30,12 +30,12 @@ export class ApexExecute {
   ): Promise<ExecuteAnonymousResponse> {
     let data: string;
 
-    if (options.apexCodeFile) {
-      if (!existsSync(options.apexCodeFile))
+    if (options.apexFilePath) {
+      if (!existsSync(options.apexFilePath))
         throw new Error(
-          nls.localize('file_not_found_error', options.apexCodeFile)
+          nls.localize('file_not_found_error', options.apexFilePath)
         );
-      data = readFileSync(options.apexCodeFile, 'utf8');
+      data = readFileSync(options.apexFilePath, 'utf8');
     } else {
       data = String(options.apexCode);
     }

--- a/packages/apex-node/src/types/service.ts
+++ b/packages/apex-node/src/types/service.ts
@@ -34,7 +34,7 @@ type CommonOptions = {
 
 export type ApexExecuteOptions = CommonOptions & {
   targetUsername?: string;
-  apexCodeFile?: string;
+  apexFilePath?: string;
   apexCode?: string | Buffer;
 };
 

--- a/packages/apex-node/test/apexService.test.ts
+++ b/packages/apex-node/test/apexService.test.ts
@@ -10,7 +10,7 @@ import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { expect } from 'chai';
 import { ExecuteAnonymousResponse } from '../src/types';
 import { ApexExecute } from '../src/commands/apexExecute';
-import { createSandbox, SinonSandbox, sandbox } from 'sinon';
+import { createSandbox, SinonSandbox } from 'sinon';
 import { ApexService } from '../src/apexService';
 import { ApexLogGet } from '../src/commands';
 
@@ -55,7 +55,7 @@ describe('Apex Service Tests', () => {
       .stub(ApexExecute.prototype, 'execute')
       .resolves(execAnonResponse);
     const response = await apexService.apexExecute({
-      apexCodeFile: 'filepath/to/anonApex/file'
+      apexFilePath: 'filepath/to/anonApex/file'
     });
     expect(response).to.eql(execAnonResponse);
   });

--- a/packages/apex-node/test/commands/apexExecute.test.ts
+++ b/packages/apex-node/test/commands/apexExecute.test.ts
@@ -80,7 +80,7 @@ describe('Apex Execute Tests', () => {
       .stub(ApexExecute.prototype, 'connectionRequest')
       .resolves(soapResponse);
     const response = await apexExecute.execute({
-      apexCodeFile: 'filepath/to/anonApex/file'
+      apexFilePath: 'filepath/to/anonApex/file'
     });
 
     expect(response).to.eql(expectedResult);
@@ -126,7 +126,7 @@ describe('Apex Execute Tests', () => {
       .resolves(soapResponse);
 
     const response = await apexExecute.execute({
-      apexCodeFile: 'filepath/to/anonApex/file'
+      apexFilePath: 'filepath/to/anonApex/file'
     });
     expect(response).to.eql(expectedResult);
   });
@@ -170,7 +170,7 @@ describe('Apex Execute Tests', () => {
       .resolves(soapResponse);
 
     const response = await apexExecute.execute({
-      apexCodeFile: 'filepath/to/anonApex/file'
+      apexFilePath: 'filepath/to/anonApex/file'
     });
     expect(response).to.eql(expectedResult);
   });
@@ -222,7 +222,7 @@ describe('Apex Execute Tests', () => {
     connRequestStub.onSecondCall().resolves(soapResponse);
 
     const response = await apexExecute.execute({
-      apexCodeFile: 'filepath/to/anonApex/file'
+      apexFilePath: 'filepath/to/anonApex/file'
     });
     expect(response).to.eql(expectedResult);
     expect(connRequestStub.calledTwice);
@@ -235,7 +235,7 @@ describe('Apex Execute Tests', () => {
     fsStub.returns(false);
 
     try {
-      await apexExecute.execute({ apexCodeFile: apexFile });
+      await apexExecute.execute({ apexFilePath: apexFile });
       assert.fail('Expected an error');
     } catch (e) {
       assert.equal(nls.localize('file_not_found_error', apexFile), e.message);


### PR DESCRIPTION
### What does this PR do?
This PR adds an argument to the `ApexExecuteOptions` to allow a buffer or string as a potential input type

### What issues does this PR fix or reference?

