### PR TITLE
chore: update npm-release-manage-orb version (@W-8108177)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,17 @@ commands:
       - npm-release-management/publish:
           use_tarfile: true
       - npm-release-management/verify-signed-package
-      - npm-release-management/create-git-tag
-
+  create-git-tag:
+    steps:
+      - run:
+          name: Current git tags
+          command: git tag
+      - run:
+          name: Create new git tag
+          command: |
+            PKG_TAG="v$(cat package.json | jq -r .version)"
+            git tag -a $PKG_TAG -m "Releasing ${PKG_TAG}"
+            git push origin $PKG_TAG
 
 parameters:
   publish:
@@ -175,6 +184,7 @@ jobs:
       - add_ssh_keys: *ssh-config
       - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - release-management-commands
+      - create-git-tag
       - run: git push origin main
       - slack/notify:
           channel: 'pdt_releases'


### PR DESCRIPTION
### What does this PR do?
Updates dependency for npm-release-manage-orb to include [this](https://github.com/forcedotcom/npm-release-management-orb/pull/18) change.

### What does this PR fix or reference?
@W-8108177@