### PR TITLE
chore: add github creds before tag creation (@W-8108177)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ commands:
       - npm-release-management/verify-signed-package
   create-git-tag:
     steps:
+      - run: *gh-config
       - run:
           name: Current git tags
           command: git tag


### PR DESCRIPTION
### What does this PR do?
Adds git hub credentials prior to creating the tag for a release.

### What issues does this PR fix or reference?
@W-8108177@

