### PR TITLE
chore: update port PR logic to handle better errors and updates for local branches

### DIFF
--- a/scripts/port-changes.js
+++ b/scripts/port-changes.js
@@ -40,122 +40,141 @@ function updateBranches(baseBranch, featureBranch) {
 }
 
 function getReleaseVersion() {
-    const releaseType = getReleaseType();
-    const currentVersion = require('../packages/apex-node/package.json').version;
-    var [version, major, minor, patch] = currentVersion.match(/^(\d+)\.?(\d+)\.?(\*|\d+)$/);
-    switch (releaseType) {
-        case 'major':
-            major = parseInt(major) + 1;
-            minor = 0;
-            patch = 0;
-            break;
-        case 'minor':
-            minor = parseInt(minor) + 1;
-            patch = 0;
-            break;
-        case 'patch':
-            patch = parseInt(patch) + 1;
-            break;
-    }
-    return `${major}.${minor}.${patch}`;
+  const releaseType = getReleaseType();
+  const currentVersion = require('../packages/apex-node/package.json').version;
+  var [version, major, minor, patch] = currentVersion.match(
+    /^(\d+)\.?(\d+)\.?(\*|\d+)$/
+  );
+  switch (releaseType) {
+    case 'major':
+      major = parseInt(major) + 1;
+      minor = 0;
+      patch = 0;
+      break;
+    case 'minor':
+      minor = parseInt(minor) + 1;
+      patch = 0;
+      break;
+    case 'patch':
+      patch = parseInt(patch) + 1;
+      break;
+  }
+  return `${major}.${minor}.${patch}`;
 }
 
 function getReleaseType() {
-    var releaseIndex = process.argv.indexOf('-r');
-    if (releaseIndex === -1) {
-        console.error('Release version type for the port PR is required. Example: \'patch\', \'minor\', or \'major\'');
-        process.exit(-1);
-    }
-    if (!/patch|minor|major/.exec(`${process.argv[releaseIndex + 1]}`)) {
-        console.error(
-            `Invalid release version type '${process.argv[releaseIndex + 1]}'. Expected patch, minor, or major.`
-        );
-        process.exit(-1);
-    }
-    return process.argv[releaseIndex + 1];
+  var releaseIndex = process.argv.indexOf('-r');
+  if (releaseIndex === -1) {
+    console.error(
+      "Release version type for the port PR is required. Example: 'patch', 'minor', or 'major'"
+    );
+    process.exit(-1);
+  }
+  if (!/patch|minor|major/.exec(`${process.argv[releaseIndex + 1]}`)) {
+    console.error(
+      `Invalid release version type '${
+        process.argv[releaseIndex + 1]
+      }'. Expected patch, minor, or major.`
+    );
+    process.exit(-1);
+  }
+  return process.argv[releaseIndex + 1];
 }
 
 function getAllDiffs(baseBranch, featureBranch) {
-    if (ADD_VERBOSE_LOGGING)
-        console.log(`\n\nStep 2: Get all diffs between branches ${baseBranch} and ${featureBranch}`);
-    return shell
-        .exec(`git log --oneline ${baseBranch}..${featureBranch}`, {
-            silent: !ADD_VERBOSE_LOGGING
-          })
-        .replace(/\n/g, ',')
-        .split(',')
-        .map(Function.prototype.call, String.prototype.trim);
+  if (ADD_VERBOSE_LOGGING)
+    console.log(
+      `\n\nStep 2: Get all diffs between branches ${baseBranch} and ${featureBranch}`
+    );
+  return shell
+    .exec(`git log --oneline ${baseBranch}..${featureBranch}`, {
+      silent: !ADD_VERBOSE_LOGGING
+    })
+    .replace(/\n/g, ',')
+    .split(',')
+    .map(Function.prototype.call, String.prototype.trim);
 }
 
 function parseCommits(commits) {
-    if (ADD_VERBOSE_LOGGING) {
-        console.log('\n\nStep 3: Parse commits');
-        console.log('Commit Parsing Results...');
+  if (ADD_VERBOSE_LOGGING) {
+    console.log('\n\nStep 3: Parse commits');
+    console.log('Commit Parsing Results...');
+  }
+  var commitMaps = [];
+  for (var i = 0; i < commits.length; i++) {
+    var commitMap = buildMapFromCommit(commits[i]);
+    if (commitMap && Object.keys(commitMap).length > 0) {
+      commitMaps.push(commitMap);
     }
-    var commitMaps = [];
-    for (var i = 0; i < commits.length; i++) {
-        var commitMap = buildMapFromCommit(commits[i]);
-        if (commitMap && Object.keys(commitMap).length > 0) {
-            commitMaps.push(commitMap);
-        }
-    }
-    return commitMaps;
+  }
+  return commitMaps;
 }
 
 function buildMapFromCommit(commit) {
-    var map = {};
-    if (commit) {
-        var commitNum = COMMIT_REGEX.exec(commit);
-        if (commitNum) {
-            var message = commit.replace(commitNum[0], '');
-            var pr = PR_REGEX.exec(commit);
-            if (pr) {
-                map[PR_NUM] = pr[0];
-                message = message.replace(pr[0], '');
-            }
-            map[COMMIT] = commitNum[0];
-            map[MESSAGE] = message.trim();
-        }
+  var map = {};
+  if (commit) {
+    var commitNum = COMMIT_REGEX.exec(commit);
+    if (commitNum) {
+      var message = commit.replace(commitNum[0], '');
+      var pr = PR_REGEX.exec(commit);
+      if (pr) {
+        map[PR_NUM] = pr[0];
+        message = message.replace(pr[0], '');
+      }
+      map[COMMIT] = commitNum[0];
+      map[MESSAGE] = message.trim();
     }
-    if (ADD_VERBOSE_LOGGING) {
-        console.log('\nCommit: ' + commit);
-        console.log(map);
-    }
-    return map;
+  }
+  if (ADD_VERBOSE_LOGGING) {
+    console.log('\nCommit: ' + commit);
+    console.log(map);
+  }
+  return map;
 }
 
 function filterDiffs(parsedCommits) {
-    if (ADD_VERBOSE_LOGGING) {
-        console.log(`\n\nStep 4: Filter out non diffs. The commits we would want to filter...`);
-        console.log('\ta) Are the same, but have a different hash.');
-        console.log('\tb) Were ported from one branch to another. Therefore, they include an additional (PR #).\n');
+  if (ADD_VERBOSE_LOGGING) {
+    console.log(
+      `\n\nStep 4: Filter out non diffs. The commits we would want to filter...`
+    );
+    console.log('\ta) Are the same, but have a different hash.');
+    console.log(
+      '\tb) Were ported from one branch to another. Therefore, they include an additional (PR #).\n'
+    );
+  }
+  var filteredMaps = [];
+  for (var i = 0; i < parsedCommits.length; i++) {
+    var commitMap = parsedCommits[i];
+    if (isTrueDiff(commitMap)) {
+      filteredMaps.push(commitMap);
     }
-    var filteredMaps = [];
-    for (var i = 0; i < parsedCommits.length; i++) {
-        var commitMap = parsedCommits[i];
-        if (isTrueDiff(commitMap)) {
-            filteredMaps.push(commitMap);
-        }
-    }
-    if (ADD_VERBOSE_LOGGING) {
-        console.log('\nFiltered Results were: ');
-        console.log(filteredMaps);
-    }
-    return filteredMaps;
+  }
+  if (ADD_VERBOSE_LOGGING) {
+    console.log('\nFiltered Results were: ');
+    console.log(filteredMaps);
+  }
+  return filteredMaps;
 }
 
 function isTrueDiff(commitMap) {
-    var mainResult = shell.exec(`git log --grep="${commitMap[MESSAGE]}" -F --oneline main`, { silent: true });
-    var noResultsFound = !mainResult || mainResult.length === 0;
-    if (noResultsFound) {
-        if (ADD_VERBOSE_LOGGING)
-            console.log(`Porting - Commit is missing from main.\n\t${commitMap[COMMIT]} ${commitMap[MESSAGE]}`);
-        return true;
-    } else {
-        if (ADD_VERBOSE_LOGGING)
-            console.log(`Filtering - Commit is present in both branches.\n\t${commitMap[COMMIT]} ${commitMap[MESSAGE]}`);
-        return false;
-    }
+  var mainResult = shell.exec(
+    `git log --grep="${commitMap[MESSAGE]}" -F --oneline main`,
+    { silent: true }
+  );
+  var noResultsFound = !mainResult || mainResult.length === 0;
+  if (noResultsFound) {
+    if (ADD_VERBOSE_LOGGING)
+      console.log(
+        `Porting - Commit is missing from main.\n\t${commitMap[COMMIT]} ${commitMap[MESSAGE]}`
+      );
+    return true;
+  } else {
+    if (ADD_VERBOSE_LOGGING)
+      console.log(
+        `Filtering - Commit is present in both branches.\n\t${commitMap[COMMIT]} ${commitMap[MESSAGE]}`
+      );
+    return false;
+  }
 }
 
 function getPortBranch(baseBranch, version) {
@@ -168,11 +187,13 @@ function getPortBranch(baseBranch, version) {
 }
 
 function getCherryPickCommits(diffList) {
-    if (ADD_VERBOSE_LOGGING)
-        console.log('\n\nStep 6: Cherry-pick diffs into new branch');
-    for (var i = diffList.length - 1; i >= 0; i--) {
-        shell.exec(`git cherry-pick --strategy=recursive -X theirs ${diffList[i][COMMIT]}`);
-    }
+  if (ADD_VERBOSE_LOGGING)
+    console.log('\n\nStep 6: Cherry-pick diffs into new branch');
+  for (var i = diffList.length - 1; i >= 0; i--) {
+    shell.exec(
+      `git cherry-pick --strategy=recursive -X theirs ${diffList[i][COMMIT]}`
+    );
+  }
 }
 
 function checkErrorCode(code, errorMessage) {


### PR DESCRIPTION
### What does this PR do?
1. Adds checks for error codes instead of strings. If an error code is not 0, we will exit with an error.
2. Changes the local branch update logic. Previously this was not accounting for fetches being performed on the current branch. By default this isn't allowed, which was causing an error. We can make use of the '-u' option, but per git man I don't believe we should use this flag. Instead, we will now just checkout main and do a pull to avoid this issue. It also ensures we always have the latest version as well.

-u flag Information:
> By default git fetch refuses to update the head which corresponds to the current branch. This flag disables the check. This is purely for the internal use for git pull to communicate with git fetch, and unless you are implementing your own Porcelain you are not supposed to use it.

### What issues does this PR fix or reference?
@W-8189197@