### PR TITLE
fix: get log query for specific number of logs

### DIFF
--- a/packages/apex-node/src/logs/logService.ts
+++ b/packages/apex-node/src/logs/logService.ts
@@ -62,14 +62,14 @@ export class LogService {
   public async getLogRecords(numberOfLogs?: number): Promise<LogRecord[]> {
     let query = 'Select Id, Application, DurationMilliseconds, Location, ';
     query +=
-      'LogLength, LogUser.Name, Operation, Request, StartTime, Status from ApexLog Order By StartTime';
+      'LogLength, LogUser.Name, Operation, Request, StartTime, Status from ApexLog Order By StartTime DESC';
 
     if (typeof numberOfLogs === 'number') {
       if (numberOfLogs <= 0) {
         throw new Error(nls.localize('num_logs_error'));
       }
       numberOfLogs = Math.min(numberOfLogs, MAX_NUM_LOGS);
-      query += ` DESC LIMIT ${numberOfLogs}`;
+      query += ` LIMIT ${numberOfLogs}`;
     }
 
     const response = (await this.connection.tooling.query(

--- a/packages/apex-node/test/logs/logService.test.ts
+++ b/packages/apex-node/test/logs/logService.test.ts
@@ -268,8 +268,8 @@ describe('Apex Log Service Tests', () => {
       const numberOfLogs = 2;
       let query = 'Select Id, Application, DurationMilliseconds, Location, ';
       query +=
-        'LogLength, LogUser.Name, Operation, Request, StartTime, Status from ApexLog Order By StartTime ';
-      query += `DESC LIMIT ${numberOfLogs}`;
+        'LogLength, LogUser.Name, Operation, Request, StartTime, Status from ApexLog Order By StartTime DESC ';
+      query += `LIMIT ${numberOfLogs}`;
       const queryStub = sandboxStub
         .stub(mockConnection.tooling, 'query')
         //@ts-ignore
@@ -284,7 +284,7 @@ describe('Apex Log Service Tests', () => {
     it('should return all log records', async () => {
       let query = 'Select Id, Application, DurationMilliseconds, Location, ';
       query +=
-        'LogLength, LogUser.Name, Operation, Request, StartTime, Status from ApexLog Order By StartTime';
+        'LogLength, LogUser.Name, Operation, Request, StartTime, Status from ApexLog Order By StartTime DESC';
       const queryStub = sandboxStub
         .stub(mockConnection.tooling, 'query')
         //@ts-ignore


### PR DESCRIPTION
### What does this PR do?
Fixes the query for get log when specifying the number of logs to be queried.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/715, https://github.com/forcedotcom/salesforcedx-vscode/issues/2698

@W-8331099@, @W-8331134@