### PR TITLE
fix: change how oclif manifest gets generated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,6 @@ commands:
             source $BASH_ENV
             git commit -m "Updated version $RELEASE_TAG"
       - run: *build
-      - run:
-          name: Generate plugin manifest
-          command: yarn manifest:generate
       - run: yarn package
   release-management-commands:
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ GitIgnoreTest2/
 
 # MacOS folder atttribute tracking
 **/.DS_Store
-
-# ignore oclif manifest file
-oclif.manifest.json

--- a/packages/plugin-apex/oclif.manifest.json
+++ b/packages/plugin-apex/oclif.manifest.json
@@ -1,0 +1,191 @@
+{
+    "version": "0.1.4",
+    "commands": {
+        "force:apex:execute": {
+            "id": "force:apex:execute",
+            "description": "executes anonymous Apex code\nExecutes one or more lines of anonymous Apex code entered on the command line, or executes the code in a local file.\nIf you don’t run this command from within a Salesforce DX project, —-targetusername is required.\nTo execute your code interactively, run this command with no parameters. At the prompt, enter all your Apex code; press CTRL-D when you're finished. Your code is then executed in a single execute anonymous request.\nFor more information, see \"Anonymous Blocks\" in the Apex Developer Guide.\n\n",
+            "usage": "<%= command.id %> [-f <filepath>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+            "pluginName": "@salesforce/plugin-apex",
+            "pluginType": "core",
+            "aliases": [],
+            "examples": [
+                "$ sfdx force:apex:execute -u testusername@salesforce.org -f ~/test.apex",
+                "$ sfdx force:apex:execute -f ~/test.apex",
+                "$ sfdx force:apex:execute \nStart typing Apex code. Press the Enter key after each line, then press CTRL+D when finished."
+            ],
+            "flags": {
+                "json": {
+                    "name": "json",
+                    "type": "boolean",
+                    "description": "format output as json",
+                    "allowNo": false
+                },
+                "loglevel": {
+                    "name": "loglevel",
+                    "type": "option",
+                    "description": "logging level for this command invocation",
+                    "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+                    "options": [
+                        "trace",
+                        "debug",
+                        "info",
+                        "warn",
+                        "error",
+                        "fatal",
+                        "TRACE",
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "ERROR",
+                        "FATAL"
+                    ],
+                    "default": "warn"
+                },
+                "targetusername": {
+                    "name": "targetusername",
+                    "type": "option",
+                    "char": "u",
+                    "description": "username or alias for the target org; overrides default target org"
+                },
+                "apiversion": {
+                    "name": "apiversion",
+                    "type": "option",
+                    "description": "override the api version used for api requests made by this command"
+                },
+                "apexcodefile": {
+                    "name": "apexcodefile",
+                    "type": "option",
+                    "char": "f",
+                    "description": "path to a local file that contains Apex code"
+                }
+            },
+            "args": []
+        },
+        "force:apex:log:get": {
+            "id": "force:apex:log:get",
+            "description": "fetch debug logs\nFetches the specified log or given number of most recent logs from the scratch org. \nTo get the IDs for your debug logs, run \"sfdx force:apex:log:list\". \nUse the --logid parameter to return a specific log. \nUse the --number parameter to return the specified number of recent logs.\nUse the --outputdir parameter to specify the directory to store the logs in.\nExecuting this command without parameters returns the most recent log.",
+            "usage": "<%= command.id %> [-i <id>] [-n <number>] [-d <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+            "pluginName": "@salesforce/plugin-apex",
+            "pluginType": "core",
+            "aliases": [],
+            "examples": [
+                "$ sfdx force:apex:log:get -i <log id>",
+                "$ sfdx force:apex:log:get -i <log id> -u me@my.org",
+                "$ sfdx force:apex:log:get -n 2 -c",
+                "$ sfdx force:apex:log:get -d Users/Desktop/logs -n 2"
+            ],
+            "flags": {
+                "json": {
+                    "name": "json",
+                    "type": "boolean",
+                    "description": "format output as JSON",
+                    "allowNo": false
+                },
+                "loglevel": {
+                    "name": "loglevel",
+                    "type": "option",
+                    "description": "logging level for this command invocation",
+                    "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+                    "options": [
+                        "trace",
+                        "debug",
+                        "info",
+                        "warn",
+                        "error",
+                        "fatal",
+                        "TRACE",
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "ERROR",
+                        "FATAL"
+                    ],
+                    "default": "warn"
+                },
+                "targetusername": {
+                    "name": "targetusername",
+                    "type": "option",
+                    "char": "u",
+                    "description": "username or alias for the target org; overrides default target org"
+                },
+                "apiversion": {
+                    "name": "apiversion",
+                    "type": "option",
+                    "description": "override the api version used for api requests made by this command"
+                },
+                "logid": {
+                    "name": "logid",
+                    "type": "option",
+                    "char": "i",
+                    "description": "id of the log to display"
+                },
+                "number": {
+                    "name": "number",
+                    "type": "option",
+                    "char": "n",
+                    "description": "number of most recent logs to display"
+                },
+                "outputdir": {
+                    "name": "outputdir",
+                    "type": "option",
+                    "char": "d",
+                    "description": "directory for saving the log files"
+                }
+            },
+            "args": []
+        },
+        "force:apex:log:list": {
+            "id": "force:apex:log:list",
+            "description": "display a list of IDs and general information about debug logs\nRun this command in a project to list the IDs and general information for all debug logs in your default org.\nTo fetch a specific log from your org, obtain the ID from this command's output, then run the “sfdx force:apex:log:get” command.",
+            "usage": "<%= command.id %> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]",
+            "pluginName": "@salesforce/plugin-apex",
+            "pluginType": "core",
+            "aliases": [],
+            "examples": [
+                "$ sfdx force:apex:log:list",
+                "$ sfdx force:apex:log:list -u me@my.org"
+            ],
+            "flags": {
+                "json": {
+                    "name": "json",
+                    "type": "boolean",
+                    "description": "format output as JSON",
+                    "allowNo": false
+                },
+                "loglevel": {
+                    "name": "loglevel",
+                    "type": "option",
+                    "description": "logging level for this command invocation",
+                    "helpValue": "(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)",
+                    "options": [
+                        "trace",
+                        "debug",
+                        "info",
+                        "warn",
+                        "error",
+                        "fatal",
+                        "TRACE",
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "ERROR",
+                        "FATAL"
+                    ],
+                    "default": "warn"
+                },
+                "targetusername": {
+                    "name": "targetusername",
+                    "type": "option",
+                    "char": "u",
+                    "description": "username or alias for the target org; overrides default target org"
+                },
+                "apiversion": {
+                    "name": "apiversion",
+                    "type": "option",
+                    "description": "override the api version used for api requests made by this command"
+                }
+            },
+            "args": []
+        }
+    }
+}

--- a/packages/plugin-apex/package.json
+++ b/packages/plugin-apex/package.json
@@ -101,7 +101,6 @@
     "format": "prettier --config ../../.prettierrc --write './{src,test,scripts}/**/*.{ts,js,json}'",
     "lint": "eslint -c .eslintrc.json --ext .ts ./src ./test",
     "manifest:generate": "yarn build && oclif-dev manifest",
-    "postpack": "shx rm -f oclif.manifest.json",
     "test": "cross-env FORCE_COLOR=true mocha --recursive \"./test/**/*.test.ts\" --full-trace",
     "version": "oclif-dev readme && git add README.md",
     "test:deprecation-policy": "./bin/run snapshot:compare",


### PR DESCRIPTION
### What does this PR do?
This PR changes the way we generate the oclif manifest to be a manual process (for now) since we want to remove the references to apex:test:run.

Without these changes, we get the following error when installing the plugin

```
Error: Cannot find module '/Users/username/.local/share/sfdx/node_modules/@salesforce/plugin-apex/lib/commands/force/apex/test/run'
```

### What issues does this PR fix or reference?
@W-8340748@