### PR TITLE
chore: updated version 0.1.15

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.14"
+  "version": "0.1.15"
 }

--- a/packages/apex-node/package.json
+++ b/packages/apex-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce js library for Apex",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/packages/plugin-apex/package.json
+++ b/packages/plugin-apex/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/plugin-apex",
   "description": "Apex commands",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
-    "@salesforce/apex-node": "0.1.14",
+    "@salesforce/apex-node": "0.1.15",
     "@salesforce/command": "3.0.3",
     "@salesforce/core": "2.13.0",
     "chalk": "^4.1.0",


### PR DESCRIPTION
### What does this PR do?
 
Port version bump to 0.1.15
