### PR TITLE
fix: handle running test class with no tests

### DIFF
--- a/packages/apex-node/src/tests/testService.ts
+++ b/packages/apex-node/src/tests/testService.ts
@@ -640,6 +640,10 @@ export class TestService {
   public async getPerClassCodeCoverage(
     apexTestClassSet: Set<string>
   ): Promise<Map<string, PerClassCoverage[]>> {
+    if (apexTestClassSet.size === 0) {
+      return new Map();
+    }
+
     let str = '';
     apexTestClassSet.forEach(elem => {
       str += `'${elem}',`;

--- a/packages/apex-node/test/tests/codeCoverage.test.ts
+++ b/packages/apex-node/test/tests/codeCoverage.test.ts
@@ -308,11 +308,7 @@ describe('Get code coverage results', () => {
   });
 
   it('should return per class coverage for test that covers 0 classes', async () => {
-    toolingQueryStub.resolves({
-      done: true,
-      totalSize: 0,
-      records: []
-    } as ApexCodeCoverage);
+    toolingQueryStub.throws('Error at Row:1;Column:1');
     const testSrv = new TestService(mockConnection);
     const perClassCoverageMap = await testSrv.getPerClassCodeCoverage(
       new Set<string>([])


### PR DESCRIPTION
### What does this PR do?
This PR handles the scenario where a user tries to run a test class that does not have any test methods ie. a test class with only an `@TestSetup` method

### What issues does this PR fix or reference?

@W-8980718@

