### PR TITLE
fix: process test results with missing stack trace

### DIFF
--- a/packages/apex-node/src/tests/testService.ts
+++ b/packages/apex-node/src/tests/testService.ts
@@ -355,11 +355,15 @@ export class TestService {
     const diagnostic: ApexDiagnostic = {
       exceptionMessage: syncRecord.message,
       exceptionStackTrace: syncRecord.stackTrace,
-      className: syncRecord.stackTrace.split('.')[1],
+      className: syncRecord.stackTrace
+        ? syncRecord.stackTrace.split('.')[1]
+        : undefined,
       compileProblem: ''
     };
 
-    const matches = syncRecord.stackTrace.match(/(line (\d+), column (\d+))/);
+    const matches =
+      syncRecord.stackTrace &&
+      syncRecord.stackTrace.match(/(line (\d+), column (\d+))/);
     if (matches) {
       if (matches[2]) {
         diagnostic.lineNumber = Number(matches[2]);
@@ -648,11 +652,15 @@ export class TestService {
     const diagnostic: ApexDiagnostic = {
       exceptionMessage: asyncRecord.Message,
       exceptionStackTrace: asyncRecord.StackTrace,
-      className: asyncRecord.StackTrace.split('.')[1],
+      className: asyncRecord.StackTrace
+        ? asyncRecord.StackTrace.split('.')[1]
+        : undefined,
       compileProblem: ''
     };
 
-    const matches = asyncRecord.StackTrace.match(/(line (\d+), column (\d+))/);
+    const matches =
+      asyncRecord.StackTrace &&
+      asyncRecord.StackTrace.match(/(line (\d+), column (\d+))/);
     if (matches) {
       if (matches[2]) {
         diagnostic.lineNumber = Number(matches[2]);

--- a/packages/apex-node/test/tests/asyncTests.test.ts
+++ b/packages/apex-node/test/tests/asyncTests.test.ts
@@ -271,6 +271,9 @@ describe('Run Apex tests asynchronously', () => {
   it('should return failed test results with missing error info', async () => {
     diagnosticFailure.summary.orgId = mockConnection.getAuthInfoFields().orgId;
     diagnosticFailure.summary.username = mockConnection.getUsername();
+    diagnosticFailure.tests[0].diagnostic.className = undefined;
+    diagnosticFailure.tests[0].diagnostic.exceptionStackTrace = undefined;
+    diagnosticFailure.tests[0].stackTrace = undefined;
     const testSrv = new TestService(mockConnection);
     const mockToolingQuery = sandboxStub.stub(mockConnection.tooling, 'query');
     mockToolingQuery.onFirstCall().resolves({
@@ -294,7 +297,7 @@ describe('Run Apex tests asynchronously', () => {
         {
           Id: '07Mxx00000F2Xx6UAF',
           QueueItemId: '7092M000000Vt94QAC',
-          StackTrace: 'Class.LIFXControllerTest.makeData',
+          StackTrace: undefined,
           Message: 'System.AssertException: Assertion Failed',
           AsyncApexJobId: testRunId,
           MethodName: 'testLoggerLog',

--- a/packages/apex-node/test/tests/syncTests.test.ts
+++ b/packages/apex-node/test/tests/syncTests.test.ts
@@ -114,7 +114,7 @@ describe('Run Apex tests synchronously', () => {
     expect(toolingRequestStub.calledOnce).to.equal(true);
     expect(testResult.summary).to.be.a('object');
     expect(testResult.summary.failRate).to.equal('100%');
-    expect(testResult.summary.testsRan).to.equal(1);
+    expect(testResult.summary.testsRan).to.equal(4);
     expect(testResult.summary.orgId).to.equal(
       mockConnection.getAuthInfoFields().orgId
     );
@@ -125,7 +125,7 @@ describe('Run Apex tests synchronously', () => {
     expect(testResult.summary.username).to.equal(mockConnection.getUsername());
 
     expect(testResult.tests).to.be.a('array');
-    expect(testResult.tests.length).to.equal(1);
+    expect(testResult.tests.length).to.equal(4);
     expect(testResult.tests[0].queueItemId).to.equal('');
     expect(testResult.tests[0].stackTrace).to.equal(
       'Class.TestSample.testOne: line 27, column 1'
@@ -145,6 +145,13 @@ describe('Run Apex tests synchronously', () => {
     expect(testResult.tests[0].runTime).to.equal(68);
     expect(testResult.tests[0].testTimestamp).to.equal('');
     expect(testResult.tests[0].fullName).to.equal('tr__TestSample.testOne');
+    expect(testResult.tests[0].diagnostic.lineNumber).to.equal(27);
+    expect(testResult.tests[0].diagnostic.columnNumber).to.equal(1);
+
+    expect(testResult.tests[3].apexClass.fullName).to.equal('tr__TestSample4');
+    expect(testResult.tests[3].stackTrace).to.equal('TestSample4: line 30');
+    expect(testResult.tests[3].diagnostic.lineNumber).to.equal(undefined);
+    expect(testResult.tests[3].diagnostic.columnNumber).to.equal(undefined);
   });
 
   it('should run a test with code coverage', async () => {

--- a/packages/apex-node/test/tests/testData.ts
+++ b/packages/apex-node/test/tests/testData.ts
@@ -36,7 +36,7 @@ export const syncTestResultWithFailures: SyncTestResult = {
   apexLogId: '07Lxx00000cxy6YUAQ',
   successes: [],
   numFailures: 0,
-  numTestsRun: 1,
+  numTestsRun: 4,
   failures: [
     {
       id: '01pxx00000NWwb3AAD',
@@ -47,6 +47,40 @@ export const syncTestResultWithFailures: SyncTestResult = {
       namespace: 'tr',
       seeAllData: false,
       stackTrace: 'Class.TestSample.testOne: line 27, column 1',
+      time: 68,
+      type: 'Class'
+    },
+    {
+      id: '01pxx00000NWwb4AAD',
+      message:
+        'System.AssertException: Assertion Failed: Expected: false, Actual: true',
+      methodName: 'testOne',
+      name: 'TestSample2',
+      namespace: 'tr',
+      seeAllData: false,
+      stackTrace: undefined,
+      time: 68,
+      type: 'Class'
+    },
+    {
+      id: '01pxx00000NWwb5AAD',
+      message: undefined,
+      methodName: 'testOne',
+      name: 'TestSample3',
+      namespace: 'tr',
+      seeAllData: false,
+      stackTrace: 'Class.TestSample3.testOne: line 27, column 1',
+      time: 68,
+      type: 'Class'
+    },
+    {
+      id: '01pxx00000NWwb6AAD',
+      message: undefined,
+      methodName: 'testOne',
+      name: 'TestSample4',
+      namespace: 'tr',
+      seeAllData: false,
+      stackTrace: 'TestSample4: line 30',
       time: 68,
       type: 'Class'
     }


### PR DESCRIPTION
### What does this PR do?

Correctly parse failed test results if the stack trace is missing

### What issues does this PR fix or reference?

@W-8979442@
