### PR TITLE
 fix(execute-service): fix 60s hang on apex:execute command

### DIFF
--- a/packages/apex-node/src/execute/executeService.ts
+++ b/packages/apex-node/src/execute/executeService.ts
@@ -94,6 +94,7 @@ export class ExecuteService {
       });
       readInterface.on('close', () => {
         resolve(apexCode);
+        clearTimeout(timeout);
       });
       readInterface.on('error', (err: Error) => {
         reject(


### PR DESCRIPTION
### What does this PR do?

fix an issue in which the command would hang for around 60s even after the apex code was already compiled and executed

### What issues does this PR fix or reference?

fixes one of the issues mentioned in https://github.com/forcedotcom/cli/issues/908

### Functionality Before

When executing `sfdx force:apex:execute` with user input, the command would hang for around 60s even though the apex code was compiled, executed and its result presented in stdout

### Functionality After

command does not hang anymore
