### PR TITLE
feat: subscribe to test run in progress with test:report command

### DIFF
--- a/packages/apex-node/src/streaming/streamingClient.ts
+++ b/packages/apex-node/src/streaming/streamingClient.ts
@@ -130,7 +130,10 @@ export class StreamingClient {
     this.client.disconnect();
   }
 
-  public async subscribe(action: () => Promise<string>): Promise<AsyncTestRun> {
+  public async subscribe(
+    action?: () => Promise<string>,
+    testRunId?: string
+  ): Promise<AsyncTestRun> {
     return new Promise((subscriptionResolve, subscriptionReject) => {
       try {
         this.client.subscribe(
@@ -148,15 +151,20 @@ export class StreamingClient {
           }
         );
 
-        action()
-          .then(id => {
-            this.subscribedTestRunId = id;
-            this.subscribedTestRunIdDeferred.resolve(id);
-          })
-          .catch(e => {
-            this.client.disconnect();
-            subscriptionReject(e);
-          });
+        if (action) {
+          action()
+            .then(id => {
+              this.subscribedTestRunId = id;
+              this.subscribedTestRunIdDeferred.resolve(id);
+            })
+            .catch(e => {
+              this.client.disconnect();
+              subscriptionReject(e);
+            });
+        } else {
+          this.subscribedTestRunId = testRunId;
+          this.subscribedTestRunIdDeferred.resolve(testRunId);
+        }
       } catch (e) {
         this.client.disconnect();
         subscriptionReject(e);

--- a/packages/plugin-apex/src/commands/force/apex/test/report.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/report.ts
@@ -13,7 +13,7 @@ import {
   ApexTestRunResultStatus
 } from '@salesforce/apex-node';
 import { flags, SfdxCommand } from '@salesforce/command';
-import { Messages } from '@salesforce/core';
+import { Messages, SfdxError } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 import {
   JsonReporter,
@@ -88,6 +88,16 @@ export default class Report extends SfdxCommand {
     if (this.flags.outputdir) {
       this.ux.warn(messages.getMessage('warningMessage'));
     }
+
+    // add listener for errors
+    process.on('uncaughtException', err => {
+      const formattedErr = this.formatError(
+        new SfdxError(messages.getMessage('apexLibErr', [err.message]))
+      );
+      this.ux.error(...formattedErr);
+      process.exit();
+    });
+
     // org is guaranteed by requiresUsername field
     const conn = this.org!.getConnection();
     const testService = new TestService(conn);


### PR DESCRIPTION
### What does this PR do?
This PR addresses an issue where the force:apex:test:report command would throw an error on test runs that were still in progress. In this PR, we're now matching the previous CLI behavior by subscribing to test runs using the Streaming API and waiting to output the results. Test runs that are already complete should still return the results immediately.

### What issues does this PR fix or reference?

#198, @W-9346853@

