### PR TITLE
fix(test): apex fullname to use . instead of __

### DIFF
--- a/packages/apex-node/src/tests/asyncTests.ts
+++ b/packages/apex-node/src/tests/asyncTests.ts
@@ -353,7 +353,7 @@ export class AsyncTests {
         apexTestClassIdSet.add(item.ApexClass.Id);
         // Can only query the FullName field if a single record is returned, so manually build the field
         item.ApexClass.FullName = item.ApexClass.NamespacePrefix
-          ? `${item.ApexClass.NamespacePrefix}__${item.ApexClass.Name}`
+          ? `${item.ApexClass.NamespacePrefix}.${item.ApexClass.Name}`
           : item.ApexClass.Name;
 
         const diagnostic =

--- a/packages/apex-node/src/tests/syncTests.ts
+++ b/packages/apex-node/src/tests/syncTests.ts
@@ -154,7 +154,7 @@ export class SyncTests {
     const apexTestClassIdSet = new Set<string>();
 
     apiTestResult.successes.forEach(item => {
-      const nms = item.namespace ? `${item.namespace}__` : '';
+      const nms = item.namespace ? `${item.namespace}.` : '';
       apexTestClassIdSet.add(item.id);
       testResults.push({
         id: '',
@@ -178,7 +178,7 @@ export class SyncTests {
     });
 
     apiTestResult.failures.forEach(item => {
-      const nms = item.namespace ? `${item.namespace}__` : '';
+      const nms = item.namespace ? `${item.namespace}.` : '';
       apexTestClassIdSet.add(item.id);
       const diagnostic =
         item.message || item.stackTrace ? getSyncDiagnostic(item) : null;

--- a/packages/apex-node/test/reporters/humanReporter.test.ts
+++ b/packages/apex-node/test/reporters/humanReporter.test.ts
@@ -20,10 +20,23 @@ describe('Human Reporter Tests', () => {
     const result = reporter.format(testResults, false);
     expect(result).to.not.be.empty;
     expect(result).to.contain(
-      'AnimalLocatorTest.testMissingAnimal                   Fail     System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual:'
+      'AnimalLocatorTest.testMissingAnimal                  Fail     System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual:'
     );
     expect(result).to.contain(
       'Class.AnimalLocatorTest.testMissingAnimal: line 22, column 1'
+    );
+    expect(result).to.contain('=== Test Results');
+    expect(result).to.contain('=== Test Summary');
+  });
+
+  it('should format test results with + without namespace', () => {
+    const result = reporter.format(testResults, false);
+    expect(result).to.not.be.empty;
+    expect(result).to.contain(
+      'AccountServiceTest.should_create_account             Pass                                                                                                           86'
+    );
+    expect(result).to.contain(
+      'trlhdtips.tt_UtilControllerTest.testResetMyPassword  Pass                                                                                                           179'
     );
     expect(result).to.contain('=== Test Results');
     expect(result).to.contain('=== Test Summary');

--- a/packages/apex-node/test/reporters/testResults.ts
+++ b/packages/apex-node/test/reporters/testResults.ts
@@ -260,11 +260,11 @@ export const testResults: TestResult = {
         id: '01p3t000003qSzaAAE',
         name: 'tt_UtilControllerTest',
         namespacePrefix: 'trlhdtips',
-        fullName: 'trlhdtips__tt_UtilControllerTest'
+        fullName: 'trlhdtips.tt_UtilControllerTest'
       },
       runTime: 13,
       testTimestamp: '2020-11-09T18:02:51.000+0000',
-      fullName: 'trlhdtips__tt_UtilControllerTest.testGetCurrentUser'
+      fullName: 'trlhdtips.tt_UtilControllerTest.testGetCurrentUser'
     },
     {
       id: '07M3t000003bQwXEAU',
@@ -279,11 +279,11 @@ export const testResults: TestResult = {
         id: '01p3t000003qSzaAAE',
         name: 'tt_UtilControllerTest',
         namespacePrefix: 'trlhdtips',
-        fullName: 'trlhdtips__tt_UtilControllerTest'
+        fullName: 'trlhdtips.tt_UtilControllerTest'
       },
       runTime: 179,
       testTimestamp: '2020-11-09T18:02:51.000+0000',
-      fullName: 'trlhdtips__tt_UtilControllerTest.testResetMyPassword'
+      fullName: 'trlhdtips.tt_UtilControllerTest.testResetMyPassword'
     },
     {
       id: '07M3t000003bQwlEAE',
@@ -357,11 +357,11 @@ export const testResults: TestResult = {
         id: '01p3t000000i4L1AAI',
         name: 'DashboardPalTest',
         namespacePrefix: 'Dashboard_Pal',
-        fullName: 'Dashboard_Pal__DashboardPalTest'
+        fullName: 'Dashboard_Pal.DashboardPalTest'
       },
       runTime: 128,
       testTimestamp: '2020-11-09T18:02:51.000+0000',
-      fullName: 'Dashboard_Pal__DashboardPalTest.testDashboardPal'
+      fullName: 'Dashboard_Pal.DashboardPalTest.testDashboardPal'
     },
     {
       id: '07M3t000003bQx0EAE',
@@ -546,9 +546,9 @@ export const junitResult = `<?xml version="1.0" encoding="UTF-8"?>
         <testcase name="testCallout" classname="AwesomeCalculatorTest" time="0.02">
             <failure message=""></failure>
         </testcase>
-        <testcase name="testGetCurrentUser" classname="trlhdtips__tt_UtilControllerTest" time="0.01">
+        <testcase name="testGetCurrentUser" classname="trlhdtips.tt_UtilControllerTest" time="0.01">
         </testcase>
-        <testcase name="testResetMyPassword" classname="trlhdtips__tt_UtilControllerTest" time="0.18">
+        <testcase name="testResetMyPassword" classname="trlhdtips.tt_UtilControllerTest" time="0.18">
         </testcase>
         <testcase name="testGetCallout" classname="AnimalLocatorTest" time="0.02">
         </testcase>
@@ -557,7 +557,7 @@ export const junitResult = `<?xml version="1.0" encoding="UTF-8"?>
         </testcase>
         <testcase name="testProcessing" classname="LeadProcessorTest" time="2.26">
         </testcase>
-        <testcase name="testDashboardPal" classname="Dashboard_Pal__DashboardPalTest" time="0.13">
+        <testcase name="testDashboardPal" classname="Dashboard_Pal.DashboardPalTest" time="0.13">
         </testcase>
         <testcase name="testCountContacts" classname="AccountProcessorTest" time="0.24">
             <failure message="System.AssertException: Assertion Failed: Incorrect count: Expected: 3, Actual: 2"><![CDATA[Class.AccountProcessorTest.testCountContacts: line 47, column 1]]></failure>

--- a/packages/apex-node/test/tests/asyncTests.test.ts
+++ b/packages/apex-node/test/tests/asyncTests.test.ts
@@ -204,7 +204,7 @@ describe('Run Apex tests asynchronously', () => {
             Id: '01pxx00000O6tXZQAZ',
             Name: 'TestLogger',
             NamespacePrefix: 't3st',
-            FullName: 't3st__TestLogger'
+            FullName: 't3st.TestLogger'
           },
           RunTime: null,
           TestTimestamp: '3'
@@ -271,7 +271,7 @@ describe('Run Apex tests asynchronously', () => {
             Id: '01pxx00000O6tXZQAZ',
             Name: 'TestLogger',
             NamespacePrefix: 't3st',
-            FullName: 't3st__TestLogger'
+            FullName: 't3st.TestLogger'
           },
           RunTime: null,
           TestTimestamp: '3'
@@ -332,7 +332,7 @@ describe('Run Apex tests asynchronously', () => {
             Id: '01pxx00000O6tXZQAZ',
             Name: 'TestLogger',
             NamespacePrefix: 't3st',
-            FullName: 't3st__TestLogger'
+            FullName: 't3st.TestLogger'
           },
           RunTime: null,
           TestTimestamp: '3'
@@ -403,7 +403,7 @@ describe('Run Apex tests asynchronously', () => {
             Id: '01pxx00000O6tXZQAZ',
             Name: 'TestLogger',
             NamespacePrefix: 't3st',
-            FullName: 't3st__TestLogger'
+            FullName: 't3st.TestLogger'
           },
           RunTime: null,
           TestTimestamp: '3'
@@ -464,7 +464,7 @@ describe('Run Apex tests asynchronously', () => {
             Id: '01pxx00000O6tXZQAZ',
             Name: 'TestLogger',
             NamespacePrefix: 't3st',
-            FullName: 't3st__TestLogger'
+            FullName: 't3st.TestLogger'
           },
           RunTime: null,
           TestTimestamp: '3'
@@ -756,7 +756,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'
@@ -780,7 +780,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'
@@ -817,7 +817,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'
@@ -865,7 +865,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'
@@ -889,7 +889,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'
@@ -944,7 +944,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'
@@ -968,7 +968,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'
@@ -1008,7 +1008,7 @@ describe('Run Apex tests asynchronously', () => {
               Id: '01pxx00000O6tXZQAZ',
               Name: 'TestLogger',
               NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
+              FullName: 't3st.TestLogger'
             },
             RunTime: 8,
             TestTimestamp: '3'

--- a/packages/apex-node/test/tests/syncTests.test.ts
+++ b/packages/apex-node/test/tests/syncTests.test.ts
@@ -158,14 +158,14 @@ describe('Run Apex tests synchronously', () => {
     expect(testResult.tests[0].apexClass.id).to.equal('01pxx00000NWwb3AAD');
     expect(testResult.tests[0].apexClass.name).to.equal('TestSample');
     expect(testResult.tests[0].apexClass.namespacePrefix).to.equal('tr');
-    expect(testResult.tests[0].apexClass.fullName).to.equal('tr__TestSample');
+    expect(testResult.tests[0].apexClass.fullName).to.equal('tr.TestSample');
     expect(testResult.tests[0].runTime).to.equal(68);
     expect(testResult.tests[0].testTimestamp).to.equal('');
-    expect(testResult.tests[0].fullName).to.equal('tr__TestSample.testOne');
+    expect(testResult.tests[0].fullName).to.equal('tr.TestSample.testOne');
     expect(testResult.tests[0].diagnostic.lineNumber).to.equal(27);
     expect(testResult.tests[0].diagnostic.columnNumber).to.equal(1);
 
-    expect(testResult.tests[3].apexClass.fullName).to.equal('tr__TestSample4');
+    expect(testResult.tests[3].apexClass.fullName).to.equal('tr.TestSample4');
     expect(testResult.tests[3].stackTrace).to.equal('TestSample4: line 30');
     expect(testResult.tests[3].diagnostic.lineNumber).to.equal(undefined);
     expect(testResult.tests[3].diagnostic.columnNumber).to.equal(undefined);

--- a/packages/apex-node/test/tests/testData.ts
+++ b/packages/apex-node/test/tests/testData.ts
@@ -126,11 +126,11 @@ export const syncResult: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestApexClass',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestApexClass'
+        fullName: 't3st.TestApexClass'
       },
       runTime: 8,
       testTimestamp: '',
-      fullName: `t3st__TestApexClass.testMethod`
+      fullName: `t3st.TestApexClass.testMethod`
     }
   ]
 };
@@ -168,11 +168,11 @@ export const testResultData: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 8,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog'
+      fullName: 't3st.TestLogger.testLoggerLog'
     }
   ]
 };
@@ -210,11 +210,11 @@ export const missingTimeTestData: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog'
+      fullName: 't3st.TestLogger.testLoggerLog'
     }
   ]
 };
@@ -252,11 +252,11 @@ export const skippedTestData: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog'
+      fullName: 't3st.TestLogger.testLoggerLog'
     }
   ]
 };
@@ -296,11 +296,11 @@ export const diagnosticResult: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog',
+      fullName: 't3st.TestLogger.testLoggerLog',
       diagnostic: {
         className: 'LIFXControllerTest',
         columnNumber: 1,
@@ -331,11 +331,11 @@ export const diagnosticFailure: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog',
+      fullName: 't3st.TestLogger.testLoggerLog',
       diagnostic: {
         className: 'LIFXControllerTest',
         compileProblem: '',


### PR DESCRIPTION
The apex fullname property will have namespace +
classname separated by a . instead of __.

This matches the input format for classnames as well as
the convention in the rest of salesforce e.g referencing
classes in a a managed package + in stacktraces.

### What does this PR do?
fixes namespace and classname to be separated by . instead of __.

### What issues does this PR fix or reference?
Fixes #205 

### Functionality Before

All test outputs would have the test name separated by __ instead of .
e.g `mynamespace__MyClass`

### Functionality After

All test outputs will have the test name separated by . instead of __
e.g `mynamespace.MyClass`
