### PR TITLE
chore: updated version 0.2.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.2"
+  "version": "0.2.3"
 }

--- a/packages/apex-node/package.json
+++ b/packages/apex-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce js library for Apex",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/packages/plugin-apex/package.json
+++ b/packages/plugin-apex/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/plugin-apex",
   "description": "Apex commands",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
-    "@salesforce/apex-node": "0.2.2",
+    "@salesforce/apex-node": "0.2.3",
     "@salesforce/command": "3.1.0",
     "@salesforce/core": "2.23.2",
     "chalk": "^4.1.0",


### PR DESCRIPTION
### What does this PR do?
Manually bump main version to 0.2.3

### What issues does this PR fix or reference?
The version bump failed to get pushed because of [dist-tags issue](https://platformcloud.slack.com/archives/C0171FWUHC1/p1626385351062500). We likely need to directly query the registry https://registry.npmjs.org/@salesforce/plugin-apex instead of running the command `npm dist-tag ls @salesforce/plugin-apex`.

