### PR TITLE
fix: query registry for dist tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
             PKG_VERSION=$(cat package.json | jq -r .version)
             MAX_TRIES=300
             TRIES=0
-            until (( $(npm dist-tag ls $PKG_NAME | grep -c $PKG_VERSION ) )) || (($TRIES >= $MAX_TRIES )); do
+            until (( $(curl -s 'https://registry.npmjs.org/'$PKG_NAME | jq '.["dist-tags"]["latest"]' | grep -c $PKG_VERSION ) )) || (($TRIES >= $MAX_TRIES )); do
                 printf '.'
                 sleep 1
                 TRIES=$((TRIES+1))


### PR DESCRIPTION
### What does this PR do?
Possibly there's a time difference between dist-tags becoming available in https://registry.npmjs.org/@salesforce/plugin-apex and when it’s available in the command `npm dist-tag ls $PKG_NAME`.

### What issues does this PR fix or reference?

@W-9357574@
