### PR TITLE
fix: fix dist tags issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,20 +72,19 @@ commands:
       - npm-release-management/publish:
           use_tarfile: true
       - run:
-          name: Wait for dist-tags to become available
+          name: Wait for version to become available on NPM
           command: |
             PKG_NAME=$(cat package.json | jq -r .name)
             PKG_VERSION=$(cat package.json | jq -r .version)
-            MAX_TRIES=300
+            MAX_TRIES=30
             TRIES=0
-            until (( $(curl -s 'https://registry.npmjs.org/'$PKG_NAME | jq '.["dist-tags"]["latest"]' | grep -c $PKG_VERSION ) )) || (($TRIES >= $MAX_TRIES )); do
+            until (($(npm view $PKG_NAME versions --json | jq "map(select(. == \"$PKG_VERSION\")) | length") > 0)) || (($TRIES >= $MAX_TRIES )); do
                 printf '.'
                 sleep 1
                 TRIES=$((TRIES+1))
             done
-
             if (($TRIES >= $MAX_TRIES)); then
-                echo "Timeout waiting for dist-tags. Exiting job"
+                echo "Timeout waiting for tag. Exiting job"
                 exit 1
             fi
       - npm-release-management/verify-signed-package


### PR DESCRIPTION
### What does this PR do?
Fixes dist-tags issue using the approach from https://github.com/forcedotcom/npm-release-management-orb/pull/11/files#diff-3ceb41195ca197a92cc89f6ea51b96bf621a2b02d64105ababd7cf03a279f424R49-R65. 

Migrating to the latest version of npm release management orb would require a bit of work since it no longer has the publish command.

### What issues does this PR fix or reference?

@W-9357574@
