### PR TITLE
chore: updated version 0.2.8

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.7"
+  "version": "0.2.8"
 }

--- a/packages/apex-node/package.json
+++ b/packages/apex-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce js library for Apex",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/packages/plugin-apex/package.json
+++ b/packages/plugin-apex/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/plugin-apex",
   "description": "Apex commands",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
-    "@salesforce/apex-node": "0.2.7",
+    "@salesforce/apex-node": "0.2.8",
     "@salesforce/command": "3.1.0",
     "@salesforce/core": "2.25.1",
     "chalk": "^4.1.0",


### PR DESCRIPTION
### What does this PR do?
Port main back to develop for v0.2.8