### PR TITLE
Output date in user's locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "salesforcedx-apex",
   "dependencies": {
+    "dateformat": "^4.5.1",
     "node": "12.4.0",
     "npm": "^6.9.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7",
     "@commitlint/config-conventional": "^7",
-    "@typescript-eslint/eslint-plugin": "^2.22.0",
+    "@types/dateformat": "^3.0.1",
     "@types/mocha": "^5",
+    "@typescript-eslint/eslint-plugin": "^2.22.0",
     "@typescript-eslint/parser": "^2.22.0",
     "commitizen": "^3.0.5",
     "cz-conventional-changelog": "^2.1.0",

--- a/packages/plugin-apex/src/commands/force/apex/log/list.ts
+++ b/packages/plugin-apex/src/commands/force/apex/log/list.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as dateformat from 'dateformat';
 import { LogRecord, LogService, Table, Row } from '@salesforce/apex-node';
 import { flags, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
@@ -135,10 +136,7 @@ export default class List extends SfdxCommand {
   }
 
   private formatTime(time: string): string {
-    const milliIndex = time.indexOf('.');
-    if (milliIndex !== -1) {
-      return time.substring(0, milliIndex) + time.substring(milliIndex + 4);
-    }
+    time = dateformat(time, 'isoDateTime');
     return time;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,6 +976,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
 
+"@types/dateformat@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
+  integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -2032,6 +2037,11 @@ dashdash@^1.12.0:
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
+
+dateformat@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.5.1.tgz#c20e7a9ca77d147906b6dc2261a8be0a5bd2173c"
+  integrity sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==
 
 debug@3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Changes the timezone output when calling `force:apex:log:list` to the user's locale instead of UTC.

Fixes #235 

e.g.
from:
`2021-08-30T04:27:08+0000`
to:
`2021-08-30T14:27:08+1000`