### PR TITLE
fix: waitFlag

### DIFF
--- a/packages/plugin-apex/src/commands/force/apex/test/run.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/run.ts
@@ -121,8 +121,7 @@ export default class Run extends SfdxCommand {
       this.ux.warn(messages.getMessage('warningMessage'));
     }
 
-    // W-9346875.  When the wait flag is present, display
-    // the results in the human readable format.
+    // W-9346875 - default to human-readable result format for --wait flag
     if (this.flags.hasOwnProperty('wait')) {
       if (!this.flags.hasOwnProperty('resultformat')) {
         this.flags.resultformat = 'human';

--- a/packages/plugin-apex/src/commands/force/apex/test/run.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/run.ts
@@ -123,8 +123,8 @@ export default class Run extends SfdxCommand {
 
     // W-9346875.  When the wait flag is present, display
     // the results in the human readable format.
-    if(this.flags.hasOwnProperty('wait')) {
-      if(!this.flags.hasOwnProperty('resultformat')) {
+    if (this.flags.hasOwnProperty('wait')) {
+      if (!this.flags.hasOwnProperty('resultformat')) {
         this.flags.resultformat = 'human';
       }
     }

--- a/packages/plugin-apex/src/commands/force/apex/test/run.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/run.ts
@@ -121,6 +121,14 @@ export default class Run extends SfdxCommand {
       this.ux.warn(messages.getMessage('warningMessage'));
     }
 
+    // W-9346875.  When the wait flag is present, display
+    // the results in the human readable format.
+    if(this.flags.hasOwnProperty('wait')) {
+      if(!this.flags.hasOwnProperty('resultformat')) {
+        this.flags.resultformat = 'human';
+      }
+    }
+
     // add listener for errors
     process.on('uncaughtException', err => {
       const formattedErr = this.formatError(

--- a/packages/plugin-apex/src/commands/force/apex/test/run.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/run.ts
@@ -122,7 +122,10 @@ export default class Run extends SfdxCommand {
     }
 
     // W-9346875 - default to human-readable result format for --wait flag
-    if (this.flags.hasOwnProperty('wait') && !this.flags.hasOwnProperty('resultformat')) {
+    if (
+      this.flags.hasOwnProperty('wait') &&
+      !this.flags.hasOwnProperty('resultformat')
+    ) {
       this.flags.resultformat = 'human';
     }
 

--- a/packages/plugin-apex/src/commands/force/apex/test/run.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/run.ts
@@ -122,10 +122,8 @@ export default class Run extends SfdxCommand {
     }
 
     // W-9346875 - default to human-readable result format for --wait flag
-    if (this.flags.hasOwnProperty('wait')) {
-      if (!this.flags.hasOwnProperty('resultformat')) {
-        this.flags.resultformat = 'human';
-      }
+    if (this.flags.hasOwnProperty('wait') && !this.flags.hasOwnProperty('resultformat')) {
+      this.flags.resultformat = 'human';
     }
 
     // add listener for errors

--- a/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
+++ b/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
@@ -1217,20 +1217,17 @@ describe('force:apex:test:run', () => {
     .stub(process, 'cwd', () => projectPath)
     .stub(TestService.prototype, 'runTestAsynchronous', () => testRunSimple)
     .stdout()
-    .command([
-      'force:apex:test:run',
-      '--tests',
-      'MyApexTests',
-      '--wait',
-      '20'
-    ])
-    .it('should return human-readable results when the wait argument is passed', ctx => {
-      const result = ctx.stdout;
-      expect(result).to.not.be.empty;
-      expect(result).to.contain('Test Summary');
-      expect(result).to.contain('Test Results');
-      expect(result).to.not.contain('to retrieve test results');
-    });
+    .command(['force:apex:test:run', '--tests', 'MyApexTests', '--wait', '20'])
+    .it(
+      'should return human-readable results when the wait argument is passed',
+      ctx => {
+        const result = ctx.stdout;
+        expect(result).to.not.be.empty;
+        expect(result).to.contain('Test Summary');
+        expect(result).to.contain('Test Results');
+        expect(result).to.not.contain('to retrieve test results');
+      }
+    );
 
   test
     .withOrg({ username: TEST_USERNAME }, true)
@@ -1249,14 +1246,17 @@ describe('force:apex:test:run', () => {
       '--resultformat',
       'json'
     ])
-    .it('should return JSON result when the wait argument is passed and the resultformat is JSON', ctx => {
-      const result = ctx.stdout;
-      expect(result).to.not.be.empty;
-      expect(result).to.not.contain('to retrieve test results');
+    .it(
+      'should return JSON result when the wait argument is passed and the resultformat is JSON',
+      ctx => {
+        const result = ctx.stdout;
+        expect(result).to.not.be.empty;
+        expect(result).to.not.contain('to retrieve test results');
 
-      const obj = JSON.parse(result);
-      expect(obj).to.exist;
-    });
+        const obj = JSON.parse(result);
+        expect(obj).to.exist;
+      }
+    );
 
   test
     .withOrg({ username: TEST_USERNAME }, true)
@@ -1274,14 +1274,17 @@ describe('force:apex:test:run', () => {
       '20',
       '--json'
     ])
-    .it('should return successful JSON result when the wait argument is passed and the output format is set to JSON', ctx => {
-      const result = ctx.stdout;
-      expect(result).to.not.be.empty;
-      expect(result).to.not.contain('to retrieve test results');
+    .it(
+      'should return successful JSON result when the wait argument is passed and the output format is set to JSON',
+      ctx => {
+        const result = ctx.stdout;
+        expect(result).to.not.be.empty;
+        expect(result).to.not.contain('to retrieve test results');
 
-      const obj = JSON.parse(result);
-      expect(obj).to.exist;
+        const obj = JSON.parse(result);
+        expect(obj).to.exist;
 
-      expect(result).to.contain('"Outcome": "Pass"');
-    });
+        expect(result).to.contain('"Outcome": "Pass"');
+      }
+    );
 });

--- a/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
+++ b/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
@@ -1249,12 +1249,39 @@ describe('force:apex:test:run', () => {
       '--resultformat',
       'json'
     ])
-    .it('should return JSON results when the wait argument is passed and the resultformat is JSON', ctx => {
+    .it('should return JSON result when the wait argument is passed and the resultformat is JSON', ctx => {
       const result = ctx.stdout;
       expect(result).to.not.be.empty;
       expect(result).to.not.contain('to retrieve test results');
 
       const obj = JSON.parse(result);
       expect(obj).to.exist;
+    });
+
+  test
+    .withOrg({ username: TEST_USERNAME }, true)
+    .loadConfig({
+      root: __dirname
+    })
+    .stub(process, 'cwd', () => projectPath)
+    .stub(TestService.prototype, 'runTestAsynchronous', () => testRunSimple)
+    .stdout()
+    .command([
+      'force:apex:test:run',
+      '--tests',
+      'MyApexTests',
+      '--wait',
+      '20',
+      '--json'
+    ])
+    .it('should return successful JSON result when the wait argument is passed and the output format is set to JSON', ctx => {
+      const result = ctx.stdout;
+      expect(result).to.not.be.empty;
+      expect(result).to.not.contain('to retrieve test results');
+
+      const obj = JSON.parse(result);
+      expect(obj).to.exist;
+
+      expect(result).to.contain('"Outcome": "Pass"');
     });
 });

--- a/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
+++ b/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
@@ -1209,8 +1209,6 @@ describe('force:apex:test:run', () => {
       expect(process.exitCode).to.eql(0);
     });
 
-
-
   test
     .withOrg({ username: TEST_USERNAME }, true)
     .loadConfig({
@@ -1226,11 +1224,37 @@ describe('force:apex:test:run', () => {
       '--wait',
       '20'
     ])
-    .it('should pass and return human-readable results when the wait argument is passed', ctx => {
+    .it('should return human-readable results when the wait argument is passed', ctx => {
       const result = ctx.stdout;
       expect(result).to.not.be.empty;
       expect(result).to.contain('Test Summary');
       expect(result).to.contain('Test Results');
       expect(result).to.not.contain('to retrieve test results');
+    });
+
+  test
+    .withOrg({ username: TEST_USERNAME }, true)
+    .loadConfig({
+      root: __dirname
+    })
+    .stub(process, 'cwd', () => projectPath)
+    .stub(TestService.prototype, 'runTestAsynchronous', () => testRunSimple)
+    .stdout()
+    .command([
+      'force:apex:test:run',
+      '--tests',
+      'MyApexTests',
+      '--wait',
+      '20',
+      '--resultformat',
+      'json'
+    ])
+    .it('should return JSON results when the wait argument is passed and the resultformat is JSON', ctx => {
+      const result = ctx.stdout;
+      expect(result).to.not.be.empty;
+      expect(result).to.not.contain('to retrieve test results');
+
+      const obj = JSON.parse(result);
+      expect(obj).to.exist;
     });
 });

--- a/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
+++ b/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
@@ -1208,4 +1208,29 @@ describe('force:apex:test:run', () => {
     .it('should set exit code as 0 for passing run', () => {
       expect(process.exitCode).to.eql(0);
     });
+
+
+
+  test
+    .withOrg({ username: TEST_USERNAME }, true)
+    .loadConfig({
+      root: __dirname
+    })
+    .stub(process, 'cwd', () => projectPath)
+    .stub(TestService.prototype, 'runTestAsynchronous', () => testRunSimple)
+    .stdout()
+    .command([
+      'force:apex:test:run',
+      '--tests',
+      'MyApexTests',
+      '--wait',
+      '20'
+    ])
+    .it('should pass and return human-readable results when the wait argument is passed', ctx => {
+      const result = ctx.stdout;
+      expect(result).to.not.be.empty;
+      expect(result).to.contain('Test Summary');
+      expect(result).to.contain('Test Results');
+      expect(result).to.not.contain('to retrieve test results');
+    });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes output when the wait flag is specified.


### What issues does this PR fix or reference?

@W-9346875@

### Functionality Before

After running, user was told to run a second command to open the report.

### Functionality After

The report is now displayed.