### PR TITLE
fix: 414-from-long-url

### DIFF
--- a/packages/apex-node/src/tests/asyncTests.ts
+++ b/packages/apex-node/src/tests/asyncTests.ts
@@ -27,9 +27,9 @@ import {
   TestResult,
   TestRunIdResult
 } from './types';
-import { addIdToQuery, calculatePercentage, isValidTestRunID } from './utils';
+import { calculatePercentage, isValidTestRunID } from './utils';
 import * as util from 'util';
-import { QUERY_CHAR_LIMIT } from './constants';
+import { QUERY_RECORD_LIMIT } from './constants';
 import { CodeCoverage } from './codeCoverage';
 
 export class AsyncTests {
@@ -295,23 +295,15 @@ export class AsyncTests {
     apexTestResultQuery += 'FROM ApexTestResult WHERE QueueItemId IN (%s)';
 
     const apexResultIds = testQueueResult.records.map(record => record.Id);
-    let formattedIds = '';
-    const queries = [];
 
     // iterate thru ids, create query with id, & compare query length to char limit
-    for (const id of apexResultIds) {
-      const newIds = addIdToQuery(formattedIds, id);
-      const query = util.format(apexTestResultQuery, `'${newIds}'`);
-
-      if (query.length > QUERY_CHAR_LIMIT) {
-        queries.push(util.format(apexTestResultQuery, `'${formattedIds}'`));
-        formattedIds = '';
-      }
-      formattedIds = addIdToQuery(formattedIds, id);
-    }
-
-    if (formattedIds.length > 0) {
-      queries.push(util.format(apexTestResultQuery, `'${formattedIds}'`));
+    const queries: string[] = [];
+    for (let i = 0; i < apexResultIds.length; i += QUERY_RECORD_LIMIT) {
+      const recordSet: string[] = apexResultIds
+        .slice(i, i + QUERY_RECORD_LIMIT)
+        .map(id => `'${id}'`);
+      const query: string = util.format(apexTestResultQuery, recordSet.join());
+      queries.push(query);
     }
 
     const queryPromises = queries.map(query => {

--- a/packages/apex-node/src/tests/asyncTests.ts
+++ b/packages/apex-node/src/tests/asyncTests.ts
@@ -302,7 +302,7 @@ export class AsyncTests {
       const recordSet: string[] = apexResultIds
         .slice(i, i + QUERY_RECORD_LIMIT)
         .map(id => `'${id}'`);
-      const query: string = util.format(apexTestResultQuery, recordSet.join());
+      const query: string = util.format(apexTestResultQuery, recordSet.join(','));
       queries.push(query);
     }
 

--- a/packages/apex-node/src/tests/asyncTests.ts
+++ b/packages/apex-node/src/tests/asyncTests.ts
@@ -302,7 +302,10 @@ export class AsyncTests {
       const recordSet: string[] = apexResultIds
         .slice(i, i + QUERY_RECORD_LIMIT)
         .map(id => `'${id}'`);
-      const query: string = util.format(apexTestResultQuery, recordSet.join(','));
+      const query: string = util.format(
+        apexTestResultQuery,
+        recordSet.join(',')
+      );
       queries.push(query);
     }
 

--- a/packages/apex-node/src/tests/codeCoverage.ts
+++ b/packages/apex-node/src/tests/codeCoverage.ts
@@ -188,7 +188,7 @@ export class CodeCoverage {
         .slice(i, i + QUERY_RECORD_LIMIT)
         .map(id => `'${id}'`);
 
-      const query: string = util.format(selectQuery, recordSet.join());
+      const query: string = util.format(selectQuery, recordSet.join(','));
       queries.push(query);
     }
 

--- a/packages/apex-node/src/tests/constants.ts
+++ b/packages/apex-node/src/tests/constants.ts
@@ -5,9 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-// Tooling API query char limit is 100,000 after v48; REST API limit for uri + headers is 16,348 bytes
-// local testing shows query char limit to be closer to ~12,300.
-// Through experimentation, the record limit is around 640 before the REST API limit is hit.
-export const QUERY_RECORD_LIMIT = 640;
+// Tooling API query char limit is 100,000 after v48; REST API limit for uri + headers is 16,348 bytes.
+// Local testing shows query char limit to be closer to ~12,300.
+// Through experimentation, the record limit is around 550 before the REST API limit is hit.
+// To err on the side of caution, the limit is reduced down  to 500.
+export const QUERY_RECORD_LIMIT = 500;
 export const CLASS_ID_PREFIX = '01p';
 export const TEST_RUN_ID_PREFIX = '707';

--- a/packages/apex-node/src/tests/constants.ts
+++ b/packages/apex-node/src/tests/constants.ts
@@ -6,7 +6,8 @@
  */
 
 // Tooling API query char limit is 100,000 after v48; REST API limit for uri + headers is 16,348 bytes
-// local testing shows query char limit to be closer to ~12,300
-export const QUERY_CHAR_LIMIT = 12300;
+// local testing shows query char limit to be closer to ~12,300.
+// Through experimentation, the record limit is around 640 before the REST API limit is hit.
+export const QUERY_RECORD_LIMIT = 640;
 export const CLASS_ID_PREFIX = '01p';
 export const TEST_RUN_ID_PREFIX = '707';

--- a/packages/apex-node/src/tests/utils.ts
+++ b/packages/apex-node/src/tests/utils.ts
@@ -36,10 +36,6 @@ export function stringify(jsonObj: object): string {
   return JSON.stringify(jsonObj, null, 2);
 }
 
-export function addIdToQuery(formattedIds: string, id: string): string {
-  return formattedIds.length === 0 ? id : `${formattedIds}','${id}`;
-}
-
 export async function queryNamespaces(
   connection: Connection
 ): Promise<NamespaceInfo[]> {

--- a/packages/apex-node/test/tests/asyncTests.test.ts
+++ b/packages/apex-node/test/tests/asyncTests.test.ts
@@ -838,14 +838,14 @@ describe('Run Apex tests asynchronously', () => {
         count++;
       }
 
-      const testQueueItems5: ApexTestQueueItem = {
+      const testQueueItems: ApexTestQueueItem = {
         done: true,
         totalSize: 1800,
         records: queueItemRecord
       };
 
       const asyncTestSrv = new AsyncTests(mockConnection);
-      await asyncTestSrv.getAsyncTestResults(testQueueItems5);
+      await asyncTestSrv.getAsyncTestResults(testQueueItems);
 
       expect(mockToolingQuery.args.length).to.equal(4);
 

--- a/packages/apex-node/test/tests/asyncTests.test.ts
+++ b/packages/apex-node/test/tests/asyncTests.test.ts
@@ -59,6 +59,7 @@ import {
 } from '../../src';
 import * as utils from '../../src/tests/utils';
 import { AsyncTests } from '../../src/tests/asyncTests';
+import { QUERY_RECORD_LIMIT } from '../../src/tests/constants';
 
 const $$ = testSetup();
 let mockConnection: Connection;
@@ -714,25 +715,25 @@ describe('Run Apex tests asynchronously', () => {
     const queryStart =
       'SELECT Id, QueueItemId, StackTrace, Message, RunTime, TestTimestamp, AsyncApexJobId, MethodName, Outcome, ApexLogId, ApexClass.Id, ApexClass.Name, ApexClass.NamespacePrefix FROM ApexTestResult WHERE QueueItemId IN ';
 
-    const record = {
-      Id: '7092M000000Vt94QAC',
-      Status: ApexTestQueueItemStatus.Completed,
-      ApexClassId: '01p2M00000O6tXZQAZ',
-      TestRunResultId: '05m2M000000TgYuQAK'
-    };
-    const records: ApexTestQueueItemRecord[] = [];
+    const queueItemRecords: ApexTestQueueItemRecord[] = [];
     const queryIds: string[] = [];
-    let count = 700;
-    while (count > 0) {
-      records.push(record);
+    const maxRecordCount = 700;
+
+    for (let i = 0; i < maxRecordCount; i++) {
+      const record = {
+        Id: `7092M000000Vt94QAC-${i}`,
+        Status: ApexTestQueueItemStatus.Completed,
+        ApexClassId: '01p2M00000O6tXZQAZ',
+        TestRunResultId: '05m2M000000TgYuQAK'
+      };
+      queueItemRecords.push(record);
       queryIds.push(record.Id);
-      count--;
     }
 
     const testQueueItems: ApexTestQueueItem = {
       done: true,
-      totalSize: 700,
-      records
+      totalSize: maxRecordCount,
+      records: queueItemRecords
     };
 
     it('should split into multiple queries if query is longer than char limit', async () => {
@@ -740,54 +741,6 @@ describe('Run Apex tests asynchronously', () => {
         mockConnection.tooling,
         'autoFetchQuery'
       );
-      mockToolingQuery.onFirstCall().resolves({
-        done: true,
-        totalSize: 600,
-        records: [
-          {
-            Id: '07Mxx00000F2Xx6UAF',
-            QueueItemId: '7092M000000Vt94QAC',
-            StackTrace: null,
-            Message: null,
-            AsyncApexJobId: testRunId,
-            MethodName: 'testLoggerLog',
-            Outcome: ApexTestResultOutcome.Pass,
-            ApexLogId: null,
-            ApexClass: {
-              Id: '01pxx00000O6tXZQAZ',
-              Name: 'TestLogger',
-              NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
-            },
-            RunTime: 8,
-            TestTimestamp: '3'
-          }
-        ]
-      } as ApexTestResult);
-      mockToolingQuery.onSecondCall().resolves({
-        done: true,
-        totalSize: 100,
-        records: [
-          {
-            Id: '07Mxx00000F2Xx6UAF',
-            QueueItemId: '7092M000000Vt94QAC',
-            StackTrace: null,
-            Message: null,
-            AsyncApexJobId: testRunId,
-            MethodName: 'testLoggerLog',
-            Outcome: ApexTestResultOutcome.Pass,
-            ApexLogId: null,
-            ApexClass: {
-              Id: '01pxx00000O6tXZQAZ',
-              Name: 'TestLogger',
-              NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
-            },
-            RunTime: 8,
-            TestTimestamp: '3'
-          }
-        ]
-      } as ApexTestResult);
 
       const asyncTestSrv = new AsyncTests(mockConnection);
       const result = await asyncTestSrv.getAsyncTestResults(testQueueItems);
@@ -801,30 +754,6 @@ describe('Run Apex tests asynchronously', () => {
         mockConnection.tooling,
         'autoFetchQuery'
       );
-      mockToolingQuery.onFirstCall().resolves({
-        done: true,
-        totalSize: 1,
-        records: [
-          {
-            Id: '07Mxx00000F2Xx6UAF',
-            QueueItemId: '7092M000000Vt94QAC',
-            StackTrace: null,
-            Message: null,
-            AsyncApexJobId: testRunId,
-            MethodName: 'testLoggerLog',
-            Outcome: ApexTestResultOutcome.Pass,
-            ApexLogId: null,
-            ApexClass: {
-              Id: '01pxx00000O6tXZQAZ',
-              Name: 'TestLogger',
-              NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
-            },
-            RunTime: 8,
-            TestTimestamp: '3'
-          }
-        ]
-      } as ApexTestResult);
 
       const asyncTestSrv = new AsyncTests(mockConnection);
       const result = await asyncTestSrv.getAsyncTestResults(pollResponse);
@@ -834,69 +763,21 @@ describe('Run Apex tests asynchronously', () => {
     });
 
     it('should format multiple queries correctly', async () => {
-      const queryOneIds = queryIds.slice(0, 125).join("','");
+      const queryOneIds = queryIds.slice(0, QUERY_RECORD_LIMIT).join("','");
       const queryOne = `${queryStart}('${queryOneIds}')`;
-      const queryTwoIds = queryIds.slice(125).join("','");
+      const queryTwoIds = queryIds.slice(QUERY_RECORD_LIMIT).join("','");
       const queryTwo = `${queryStart}('${queryTwoIds}')`;
 
       const testQueueItems: ApexTestQueueItem = {
         done: true,
-        totalSize: 700,
-        records
+        totalSize: maxRecordCount,
+        records: queueItemRecords
       };
 
       const mockToolingQuery = sandboxStub.stub(
         mockConnection.tooling,
         'autoFetchQuery'
       );
-      mockToolingQuery.onFirstCall().resolves({
-        done: true,
-        totalSize: 600,
-        records: [
-          {
-            Id: '07Mxx00000F2Xx6UAF',
-            QueueItemId: '7092M000000Vt94QAC',
-            StackTrace: null,
-            Message: null,
-            AsyncApexJobId: testRunId,
-            MethodName: 'testLoggerLog',
-            Outcome: ApexTestResultOutcome.Pass,
-            ApexLogId: null,
-            ApexClass: {
-              Id: '01pxx00000O6tXZQAZ',
-              Name: 'TestLogger',
-              NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
-            },
-            RunTime: 8,
-            TestTimestamp: '3'
-          }
-        ]
-      } as ApexTestResult);
-      mockToolingQuery.onSecondCall().resolves({
-        done: true,
-        totalSize: 100,
-        records: [
-          {
-            Id: '07Mxx00000F2Xx6UAF',
-            QueueItemId: '7092M000000Vt94QAC',
-            StackTrace: null,
-            Message: null,
-            AsyncApexJobId: testRunId,
-            MethodName: 'testLoggerLog',
-            Outcome: ApexTestResultOutcome.Pass,
-            ApexLogId: null,
-            ApexClass: {
-              Id: '01pxx00000O6tXZQAZ',
-              Name: 'TestLogger',
-              NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
-            },
-            RunTime: 8,
-            TestTimestamp: '3'
-          }
-        ]
-      } as ApexTestResult);
 
       const asyncTestSrv = new AsyncTests(mockConnection);
       const result = await asyncTestSrv.getAsyncTestResults(testQueueItems);
@@ -908,74 +789,19 @@ describe('Run Apex tests asynchronously', () => {
     });
 
     it('should format query at query limit correctly', async () => {
-      const record = {
-        Id: '7092M000000Vt94QAC',
-        Status: ApexTestQueueItemStatus.Completed,
-        ApexClassId: '01p2M00000O6tXZQAZ',
-        TestRunResultId: '05m2M000000TgYuQAK'
-      };
-
-      const queryOneIds = queryIds.slice(0, 125).join("','");
+      const queryOneIds = queryIds.slice(0, QUERY_RECORD_LIMIT).join("','");
       const queryOne = `${queryStart}('${queryOneIds}')`;
 
       const testQueueItems: ApexTestQueueItem = {
         done: true,
-        totalSize: 700,
-        records
+        totalSize: maxRecordCount,
+        records: queueItemRecords
       };
 
       const mockToolingQuery = sandboxStub.stub(
         mockConnection.tooling,
         'autoFetchQuery'
       );
-      mockToolingQuery.onFirstCall().resolves({
-        done: true,
-        totalSize: 600,
-        records: [
-          {
-            Id: '07Mxx00000F2Xx6UAF',
-            QueueItemId: '7092M000000Vt94QAC',
-            StackTrace: null,
-            Message: null,
-            AsyncApexJobId: testRunId,
-            MethodName: 'testLoggerLog',
-            Outcome: ApexTestResultOutcome.Pass,
-            ApexLogId: null,
-            ApexClass: {
-              Id: '01pxx00000O6tXZQAZ',
-              Name: 'TestLogger',
-              NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
-            },
-            RunTime: 8,
-            TestTimestamp: '3'
-          }
-        ]
-      } as ApexTestResult);
-      mockToolingQuery.onSecondCall().resolves({
-        done: true,
-        totalSize: 100,
-        records: [
-          {
-            Id: '07Mxx00000F2Xx6UAF',
-            QueueItemId: '7092M000000Vt94QAC',
-            StackTrace: null,
-            Message: null,
-            AsyncApexJobId: testRunId,
-            MethodName: 'testLoggerLog',
-            Outcome: ApexTestResultOutcome.Pass,
-            ApexLogId: null,
-            ApexClass: {
-              Id: '01pxx00000O6tXZQAZ',
-              Name: 'TestLogger',
-              NamespacePrefix: 't3st',
-              FullName: 't3st__TestLogger'
-            },
-            RunTime: 8,
-            TestTimestamp: '3'
-          }
-        ]
-      } as ApexTestResult);
 
       const asyncTestSrv = new AsyncTests(mockConnection);
       const result = await asyncTestSrv.getAsyncTestResults(testQueueItems);
@@ -983,7 +809,69 @@ describe('Run Apex tests asynchronously', () => {
       expect(mockToolingQuery.calledTwice).to.be.true;
       expect(result.length).to.eql(2);
       expect(mockToolingQuery.calledWith(queryOne)).to.be.true;
-      expect(mockToolingQuery.calledWith(`${queryStart}('${record.Id}')`));
+      expect(
+        mockToolingQuery.calledWith(`${queryStart}('7092M000000Vt94QAC-0')`)
+      );
+    });
+
+    it('should split the queue into chunks of 640 records', async () => {
+      const queryStart =
+        'SELECT Id, QueueItemId, StackTrace, Message, RunTime, TestTimestamp, AsyncApexJobId, MethodName, Outcome, ApexLogId, ApexClass.Id, ApexClass.Name, ApexClass.NamespacePrefix FROM ApexTestResult WHERE QueueItemId IN ';
+      const queryStartSeparatorCount = queryStart.split(',').length - 1;
+
+      const mockToolingQuery = sandboxStub.stub(
+        mockConnection.tooling,
+        'autoFetchQuery'
+      );
+
+      const queueItemRecord: ApexTestQueueItemRecord[] = [];
+
+      let count = 0;
+      while (count < 2000) {
+        const record = {
+          Id: `7092M000000Vt94QAC-${count}`,
+          Status: ApexTestQueueItemStatus.Completed,
+          ApexClassId: '01p2M00000O6tXZQAZ',
+          TestRunResultId: '05m2M000000TgYuQAK'
+        };
+        queueItemRecord.push(record);
+        count++;
+      }
+
+      const testQueueItems5: ApexTestQueueItem = {
+        done: true,
+        totalSize: 2000,
+        records: queueItemRecord
+      };
+
+      const asyncTestSrv = new AsyncTests(mockConnection);
+      await asyncTestSrv.getAsyncTestResults(testQueueItems5);
+
+      expect(mockToolingQuery.args.length).to.equal(4);
+
+      const callOneIdCount =
+        mockToolingQuery.getCall(0).args[0].split(',').length -
+        queryStartSeparatorCount;
+      expect(callOneIdCount).to.equal(QUERY_RECORD_LIMIT);
+
+      const callTwoIdCount =
+        mockToolingQuery.getCall(1).args[0].split(',').length -
+        queryStartSeparatorCount;
+      expect(callTwoIdCount).to.equal(QUERY_RECORD_LIMIT);
+
+      const callThreeIdCount =
+        mockToolingQuery.getCall(2).args[0].split(',').length -
+        queryStartSeparatorCount;
+      expect(callThreeIdCount).to.equal(QUERY_RECORD_LIMIT);
+
+      const callFourIdCount =
+        mockToolingQuery.getCall(3).args[0].split(',').length -
+        queryStartSeparatorCount;
+      expect(callFourIdCount).to.equal(80);
+
+      expect(
+        callOneIdCount + callTwoIdCount + callThreeIdCount + callFourIdCount
+      ).to.equal(2000);
     });
 
     it('should format single query correctly', async () => {

--- a/packages/apex-node/test/tests/asyncTests.test.ts
+++ b/packages/apex-node/test/tests/asyncTests.test.ts
@@ -814,7 +814,7 @@ describe('Run Apex tests asynchronously', () => {
       );
     });
 
-    it('should split the queue into chunks of 640 records', async () => {
+    it('should split the queue into chunks of 500 records', async () => {
       const queryStart =
         'SELECT Id, QueueItemId, StackTrace, Message, RunTime, TestTimestamp, AsyncApexJobId, MethodName, Outcome, ApexLogId, ApexClass.Id, ApexClass.Name, ApexClass.NamespacePrefix FROM ApexTestResult WHERE QueueItemId IN ';
       const queryStartSeparatorCount = queryStart.split(',').length - 1;
@@ -827,7 +827,7 @@ describe('Run Apex tests asynchronously', () => {
       const queueItemRecord: ApexTestQueueItemRecord[] = [];
 
       let count = 0;
-      while (count < 2000) {
+      while (count < 1800) {
         const record = {
           Id: `7092M000000Vt94QAC-${count}`,
           Status: ApexTestQueueItemStatus.Completed,
@@ -840,7 +840,7 @@ describe('Run Apex tests asynchronously', () => {
 
       const testQueueItems5: ApexTestQueueItem = {
         done: true,
-        totalSize: 2000,
+        totalSize: 1800,
         records: queueItemRecord
       };
 
@@ -867,11 +867,11 @@ describe('Run Apex tests asynchronously', () => {
       const callFourIdCount =
         mockToolingQuery.getCall(3).args[0].split(',').length -
         queryStartSeparatorCount;
-      expect(callFourIdCount).to.equal(80);
+      expect(callFourIdCount).to.equal(300);
 
       expect(
         callOneIdCount + callTwoIdCount + callThreeIdCount + callFourIdCount
-      ).to.equal(2000);
+      ).to.equal(1800);
     });
 
     it('should format single query correctly', async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes issue where a 414 error was being returned when the Apex REST API was called with an URI that was too long.

### What issues does this PR fix or reference?

@W-9179311@

### Functionality Before

When running `sfdx force:apex:test:run -u oneappexchangeperf -r human -c -l RunLocalTests -w 1440 --verbose` (an org with a large number of Apex tests), a result of `<h1>Bad Message 414</h1><pre>reason: URI Too Long</pre>` would be displayed.

### Functionality After

The tests now run successfully