### PR TITLE
Adjustment to commands to make `flagsConfig` public static readonly

### DIFF
--- a/packages/plugin-apex/src/commands/force/apex/execute.ts
+++ b/packages/plugin-apex/src/commands/force/apex/execute.ts
@@ -36,7 +36,7 @@ export default class Execute extends SfdxCommand {
   ];
   protected static requiresUsername = true;
 
-  protected static flagsConfig = {
+  public static readonly flagsConfig = {
     apexcodefile: flags.filepath({
       char: 'f',
       description: messages.getMessage('apexCodeFileDescription')

--- a/packages/plugin-apex/src/commands/force/apex/log/get.ts
+++ b/packages/plugin-apex/src/commands/force/apex/log/get.ts
@@ -30,7 +30,7 @@ export default class Get extends SfdxCommand {
     `$ sfdx force:apex:log:get -d Users/Desktop/logs -n 2`
   ];
 
-  protected static flagsConfig = {
+  public static readonly flagsConfig = {
     json: flags.boolean({
       description: messages.getMessage('jsonDescription')
     }),

--- a/packages/plugin-apex/src/commands/force/apex/log/list.ts
+++ b/packages/plugin-apex/src/commands/force/apex/log/list.ts
@@ -27,7 +27,7 @@ export default class List extends SfdxCommand {
     `$ sfdx force:apex:log:list -u me@my.org`
   ];
 
-  protected static flagsConfig = {
+  public static readonly flagsConfig = {
     json: flags.boolean({
       description: messages.getMessage('jsonDescription')
     }),

--- a/packages/plugin-apex/src/commands/force/apex/log/tail.ts
+++ b/packages/plugin-apex/src/commands/force/apex/log/tail.ts
@@ -29,7 +29,7 @@ export default class Tail extends SfdxCommand {
     `$ sfdx force:apex:log:tail -c -s`
   ];
 
-  protected static flagsConfig = {
+  public static readonly flagsConfig = {
     json: flags.boolean({
       description: messages.getMessage('jsonDescription')
     }),

--- a/packages/plugin-apex/src/commands/force/apex/test/report.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/report.ts
@@ -46,7 +46,7 @@ export default class Report extends SfdxCommand {
     `$ sfdx force:apex:test:report -i <test run id> -c -d <path to outputdir> -u me@myorg`
   ];
 
-  protected static flagsConfig = {
+  public static readonly flagsConfig = {
     testrunid: flags.string({
       char: 'i',
       description: messages.getMessage('testRunIdDescription'),

--- a/packages/plugin-apex/src/commands/force/apex/test/run.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/run.ts
@@ -56,7 +56,7 @@ export default class Run extends SfdxCommand {
     `$ sfdx force:apex:test:run -l RunLocalTests -d <path to outputdir> -u me@my.org`
   ];
 
-  protected static flagsConfig = {
+  public static readonly flagsConfig = {
     json: flags.boolean({
       description: messages.getMessage('jsonDescription')
     }),
@@ -221,7 +221,7 @@ export default class Run extends SfdxCommand {
       if (
         result.hasOwnProperty('summary') &&
         (result as TestResult).summary.outcome ===
-          ApexTestRunResultStatus.Failed
+        ApexTestRunResultStatus.Failed
       ) {
         process.exitCode = FAILURE_EXIT_CODE;
       }


### PR DESCRIPTION
### What does this PR do?
This change allows the commands to be referenced from other custom plugins and those custom plugins will be able to dynamically reference the flags configured.  Making them "readonly" will ensure that the flags are not altered.

### What issues does this PR fix or reference?
n/a

### Functionality Before

The `flagsConfig` variable was only accessible if the commands were sub-classed.  The information would not be accessible if the command was run by another command.

### Functionality After

The `flagsConfig` variables would be accessible to other commands calling these commands.
