### PR TITLE
fix: apex code coverage flag

### DIFF
--- a/contributing/commands.md
+++ b/contributing/commands.md
@@ -178,7 +178,7 @@ USAGE
 
 OPTIONS
   -c, --codecoverage
-      retrieves code coverage results
+      runs code coverage and retrieves results
 
   -d, --outputdir=outputdir
       directory to store test run files
@@ -241,6 +241,7 @@ DESCRIPTION
   output displays a high-level summary of the test run and the code coverage values for 
   classes in your org. If you specify human-readable result format, use the 
   --detailedcoverage parameter to see detailed coverage results for each test method run.
+  If --codecoverage is not included, code coverage will be skipped during the test run.
 
   NOTE: The testRunCoverage value (JSON and JUnit result formats) is a percentage of the 
   covered lines and total lines from all the Apex classes evaluated by the tests in this 

--- a/contributing/developing.md
+++ b/contributing/developing.md
@@ -67,6 +67,14 @@ $ yarn test
 
 > When running tests, code changes don't need to be built with `yarn build` first because the test suite uses ts-node as its runtime environment. Otherwise, run `yarn build` before manually testing changes.
 
+### Running Individual Tests
+
+While developing, you may temporarily edit the `test` command in the package.json of the package you are developing in to limit the command to your individual test file. For instance:
+
+```
+$ "test": "cross-env FORCE_COLOR=true mocha --recursive \"./test/**/run.test.ts\" --full-trace",
+```
+
 <br />
 
 ### Debugging the Plugin
@@ -83,6 +91,12 @@ Alternatively, replace `sfdx` with `NODE_OPTIONS=--inspect-brk bin/run` and run 
 
 ```
 $ NODE_OPTIONS=--inspect-brk bin/run force:apex:log:list -u myOrg@example.com
+```
+
+The inspect-brk option can also be used for debugging tests:
+
+```
+NODE_OPTIONS=--inspect-brk yarn test
 ```
 
 2. Set some breakpoints in your code.

--- a/packages/apex-node/src/tests/types.ts
+++ b/packages/apex-node/src/tests/types.ts
@@ -48,6 +48,9 @@ export type AsyncTestConfiguration = {
    * Specifies which tests to run, default level is RunSpecifiedTests
    */
   testLevel: TestLevel;
+  /**
+   * Allows for faster tests by skipping code coverage
+   */
   skipCodeCoverage?: boolean;
   /**
    * Does not wait for test run to complete and returns the test run id immediately
@@ -106,6 +109,10 @@ export type AsyncTestArrayConfiguration = {
    * Does not wait for test run to complete and returns the test run id immediately
    */
   exitOnTestRunId?: boolean;
+  /**
+   * Allows for faster tests by skipping code coverage
+   */
+  skipCodeCoverage?: boolean;
 };
 
 export type SyncTestConfiguration = {
@@ -123,6 +130,10 @@ export type SyncTestConfiguration = {
    * Valid value ranges from 0 to 1,000,000. A value of 0 causes the test run to stop if any failure occurs.
    */
   maxFailedTests?: number;
+  /**
+   * Allows for faster tests by skipping code coverage
+   */
+  skipCodeCoverage?: boolean;
 };
 
 export type SyncTestSuccess = {

--- a/packages/plugin-apex/src/commands/force/apex/test/run.ts
+++ b/packages/plugin-apex/src/commands/force/apex/test/run.ts
@@ -163,6 +163,7 @@ export default class Run extends SfdxCommand {
         this.flags.tests,
         this.flags.classnames
       );
+      payload.skipCodeCoverage = this.flags.codecoverage ? false : true;
       result = (await testService.runTestSynchronous(
         payload,
         this.flags.codecoverage,
@@ -175,6 +176,7 @@ export default class Run extends SfdxCommand {
         this.flags.classnames,
         this.flags.suitenames
       );
+      payload.skipCodeCoverage = this.flags.codecoverage ? false : true;
       const reporter = undefined;
       if (this.flags.resultformat !== undefined) {
         result = await testService.runTestAsynchronous(

--- a/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
+++ b/packages/plugin-apex/test/commands/force/apex/test/run.test.ts
@@ -376,15 +376,19 @@ describe('force:apex:test:run', () => {
       'force:apex:test:run',
       '--classnames',
       'MyApexTests',
-      '--synchronous'
+      '--synchronous',
+      '--resultformat',
+      'json',
+      '-c'
     ])
     .it(
-      'should format request with correct properties for sync run with class name',
+      'should format request with correct properties for sync code coverage run with class name',
       ctx => {
         expect(
           (ctx.myStub as SinonStub).calledWith({
             tests: [{ className: 'MyApexTests' }],
-            testLevel: 'RunSpecifiedTests'
+            testLevel: 'RunSpecifiedTests',
+            skipCodeCoverage: false
           })
         ).to.be.true;
       }
@@ -416,7 +420,8 @@ describe('force:apex:test:run', () => {
         expect(
           (ctx.myStub as SinonStub).calledWith({
             tests: [{ classId: '01p45678x123456' }],
-            testLevel: 'RunSpecifiedTests'
+            testLevel: 'RunSpecifiedTests',
+            skipCodeCoverage: true
           })
         ).to.be.true;
       }
@@ -453,7 +458,8 @@ describe('force:apex:test:run', () => {
                 testMethods: ['testMethodOne']
               }
             ],
-            testLevel: 'RunSpecifiedTests'
+            testLevel: 'RunSpecifiedTests',
+            skipCodeCoverage: true
           })
         ).to.be.true;
       }
@@ -477,8 +483,13 @@ describe('force:apex:test:run', () => {
     .it(
       'should format request with correct properties for sync run with no tests or classname parameters specified',
       ctx => {
-        expect((ctx.mySpy as SinonSpy).calledWith(TestLevel.RunLocalTests)).to
-          .be.true;
+        expect(
+          (ctx.myStub as SinonSpy).calledWith({
+            suiteNames: undefined,
+            testLevel: TestLevel.RunLocalTests,
+            skipCodeCoverage: true
+          })
+        ).to.be.true;
         expect(ctx.stdout).to.not.be.empty;
         expect(ctx.stdout).to.contain(
           new HumanReporter().format(testRunSimple, false)
@@ -509,8 +520,13 @@ describe('force:apex:test:run', () => {
     .it(
       'should format request with correct properties for sync run with RunAllTestsInOrg test level specified',
       ctx => {
-        expect((ctx.mySpy as SinonSpy).calledWith(TestLevel.RunAllTestsInOrg))
-          .to.be.true;
+        expect(
+          (ctx.myStub as SinonSpy).calledWith({
+            suiteNames: undefined,
+            testLevel: TestLevel.RunAllTestsInOrg,
+            skipCodeCoverage: true
+          })
+        ).to.be.true;
         expect(ctx.stdout).to.not.be.empty;
         expect(ctx.stdout).to.contain(
           new HumanReporter().format(testRunSimple, false)
@@ -536,8 +552,13 @@ describe('force:apex:test:run', () => {
     .it(
       'should format request with correct properties and display correct info for async run with no tests or classname parameters specified',
       ctx => {
-        expect((ctx.mySpy as SinonSpy).calledWith(TestLevel.RunLocalTests)).to
-          .be.true;
+        expect(
+          (ctx.myStub as SinonSpy).calledWith({
+            suiteNames: undefined,
+            testLevel: TestLevel.RunLocalTests,
+            skipCodeCoverage: true
+          })
+        ).to.be.true;
         expect(ctx.stdout).to.not.be.empty;
         expect(ctx.stdout).to.contain('Run "sfdx force:apex:test:report');
       }


### PR DESCRIPTION
### What does this PR do?

Changed apex test run payload to set skipCodeCoverage. When code coverage is not called for,
skipCodeCoverage is now set to true. It is set to false when code coverage is specified. This fixes
an issue where code coverage was being run with every test, because this flag was omitted. Updated
corresponding tests to check for payload change.

### What issues does this PR fix or reference?
VS Code: #3541
@W-10221888@

### Functionality Before
Code coverage was being run for all tests (can query from the Tooling API with `SELECT Id, TestMethodName FROM ApexCodeCoverage`).

### Functionality After
Code coverage is only run in the org when the code coverage flag (-c) is added to the command. Otherwise, it does not run (in both synch and async executions).
