### PR TITLE
fix(junit-reporter): remove redundant intermediate locale conversion of test start time

### DIFF
--- a/packages/apex-node/src/reporters/junitReporter.ts
+++ b/packages/apex-node/src/reporters/junitReporter.ts
@@ -29,7 +29,7 @@ export class JUnitReporter {
     let output = `<?xml version="1.0" encoding="UTF-8"?>\n`;
     output += `<testsuites>\n`;
     output += `${tab}<testsuite name="force.apex" `;
-    output += `timestamp="${new Date(summary.testStartTime).toISOString()}" `;
+    output += `timestamp="${summary.testStartTime}" `;
     output += `hostname="${summary.hostname}" `;
     output += `tests="${summary.testsRan}" `;
     output += `failures="${summary.failing}"  `;

--- a/packages/apex-node/src/utils/dateUtil.ts
+++ b/packages/apex-node/src/utils/dateUtil.ts
@@ -12,13 +12,12 @@ export function getCurrentTime(): number {
 }
 
 /**
- * Returns the formatted date and time given the milliseconds in numbers or UTC formatted string
+ * Returns ISO formatted date and time given the milliseconds in numbers or UTC formatted string
  * @param startTime start time in millisecond numbers or UTC format string
- * @returns date and time formatted for locale
+ * @returns date and time formatted to ISO format
  */
 export function formatStartTime(startTime: string | number): string {
-  const date = new Date(startTime);
-  return `${date.toDateString()} ${date.toLocaleTimeString()}`;
+  return new Date(startTime).toISOString();
 }
 
 export function msToSecond(timestamp: string | number): string {

--- a/packages/apex-node/test/reporters/junitReporter.test.ts
+++ b/packages/apex-node/test/reporters/junitReporter.test.ts
@@ -78,7 +78,7 @@ describe('JUnit Reporter Tests', () => {
 
     let formatError = '';
     try {
-      formatStartTime(testLocaleStartTime); 
+      formatStartTime(testLocaleStartTime);
     } catch (error) {
       formatError = error;
     }

--- a/packages/apex-node/test/reporters/junitReporter.test.ts
+++ b/packages/apex-node/test/reporters/junitReporter.test.ts
@@ -63,25 +63,4 @@ describe('JUnit Reporter Tests', () => {
     expect(result).to.eql(junitCodeCov);
     expect(result).to.contain('orgWideCoverage');
   });
-
-  it('should format start time even when custom locale is used', () => {
-    const date = new Date();
-    // Use locale that produces time with a.m./p.m. that results in
-    // "Invalid time value" error with node v14 (Issue #213)
-    const testLocaleStartTime = date.toLocaleString('en-CA');
-    console.log('testLocaleStartTime', testLocaleStartTime);
-
-    // check for presence of a.m./p.m. in locale time
-    expect(new RegExp(`.*[a|p]\.m\.$`).test(testLocaleStartTime)).to.equal(
-      true
-    );
-
-    let formatError = '';
-    try {
-      formatStartTime(testLocaleStartTime);
-    } catch (error) {
-      formatError = error;
-    }
-    expect(formatError.toString()).to.contain('Invalid time value');
-  });
 });

--- a/packages/apex-node/test/reporters/junitReporter.test.ts
+++ b/packages/apex-node/test/reporters/junitReporter.test.ts
@@ -6,6 +6,7 @@
  */
 import { expect } from 'chai';
 import { JUnitReporter } from '../../src';
+import { formatStartTime, getCurrentTime } from '../../src/utils';
 import {
   testResults,
   junitResult,
@@ -61,5 +62,18 @@ describe('JUnit Reporter Tests', () => {
     expect(result).to.not.be.empty;
     expect(result).to.eql(junitCodeCov);
     expect(result).to.contain('orgWideCoverage');
+  });
+
+  it('should format start time even when custom locale is used', () => {
+    // set process.env LC_ALL=en_CA
+    process.env.LC_ALL = 'en_CA';
+    const date = new Date();
+    const testStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
+    // TODO: add regex check for presence of a.m / pm. in testStartTime
+    // expect(new RegExp(/.*[a|p]\.m\.$/g).test(testStartTime)).to.equal(true);
+    const timestamp = new Date(testStartTime).toISOString();
+    // Date value should be the same after formatting with locale
+    // Ignore the loss of precision (last field of milliseconds) in formatting conversion
+    expect(timestamp.split('.')[0]).to.equal(date.toISOString().split('.')[0]);
   });
 });

--- a/packages/apex-node/test/reporters/junitReporter.test.ts
+++ b/packages/apex-node/test/reporters/junitReporter.test.ts
@@ -6,7 +6,7 @@
  */
 import { expect } from 'chai';
 import { JUnitReporter } from '../../src';
-import { formatStartTime, getCurrentTime } from '../../src/utils';
+import { formatStartTime } from '../../src/utils';
 import {
   testResults,
   junitResult,
@@ -65,13 +65,12 @@ describe('JUnit Reporter Tests', () => {
   });
 
   it('should format start time even when custom locale is used', () => {
-    // set process.env LC_ALL=en_CA
-    process.env.LC_ALL = 'en_CA';
+    process.env.LC_ALL = 'en_CA'; // TODO: clear/restore after test
     const date = new Date();
     const testStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
     // TODO: add regex check for presence of a.m / pm. in testStartTime
     // expect(new RegExp(/.*[a|p]\.m\.$/g).test(testStartTime)).to.equal(true);
-    const timestamp = new Date(testStartTime).toISOString();
+    const timestamp = formatStartTime(testStartTime);
     // Date value should be the same after formatting with locale
     // Ignore the loss of precision (last field of milliseconds) in formatting conversion
     expect(timestamp.split('.')[0]).to.equal(date.toISOString().split('.')[0]);

--- a/packages/apex-node/test/reporters/junitReporter.test.ts
+++ b/packages/apex-node/test/reporters/junitReporter.test.ts
@@ -65,14 +65,23 @@ describe('JUnit Reporter Tests', () => {
   });
 
   it('should format start time even when custom locale is used', () => {
-    process.env.LC_ALL = 'en_CA'; // TODO: clear/restore after test
     const date = new Date();
-    const testStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
-    // TODO: add regex check for presence of a.m / pm. in testStartTime
-    // expect(new RegExp(/.*[a|p]\.m\.$/g).test(testStartTime)).to.equal(true);
-    const timestamp = formatStartTime(testStartTime);
-    // Date value should be the same after formatting with locale
-    // Ignore the loss of precision (last field of milliseconds) in formatting conversion
-    expect(timestamp.split('.')[0]).to.equal(date.toISOString().split('.')[0]);
+    // Use locale that produces time with a.m./p.m. that results in
+    // "Invalid time value" error with node v14 (Issue #213)
+    const testLocaleStartTime = date.toLocaleString('en-CA');
+    console.log('testLocaleStartTime', testLocaleStartTime);
+
+    // check for presence of a.m./p.m. in locale time
+    expect(new RegExp(`.*[a|p]\.m\.$`).test(testLocaleStartTime)).to.equal(
+      true
+    );
+
+    let formatError = '';
+    try {
+      formatStartTime(testLocaleStartTime); 
+    } catch (error) {
+      formatError = error;
+    }
+    expect(formatError.toString()).to.contain('Invalid time value');
   });
 });

--- a/packages/apex-node/test/reporters/testResults.ts
+++ b/packages/apex-node/test/reporters/testResults.ts
@@ -10,7 +10,7 @@ import { ApexTestResultOutcome, TestResult } from '../../src/tests/types';
 
 const testStartTime = '2020-11-09T18:02:50.000+0000';
 const date = new Date(testStartTime);
-const localStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
+const localStartTime = date.toISOString();
 
 export const coverageResult: TestResult = {
   summary: {
@@ -614,7 +614,7 @@ const codeCovProperties = `${missingValProperties}\n            <property name="
 
 const successTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-    <testsuite name="force.apex" timestamp="2020-11-09T18:02:50.000Z" hostname="https://na139.salesforce.com" tests="2" failures="0"  errors="0"  time="5.46">
+    <testsuite name="force.apex" timestamp="${testStartTime}" hostname="https://na139.salesforce.com" tests="2" failures="0"  errors="0"  time="5.46">
         <properties>
 %s
         </properties>

--- a/packages/apex-node/test/reporters/testResults.ts
+++ b/packages/apex-node/test/reporters/testResults.ts
@@ -7,10 +7,7 @@
 
 import * as util from 'util';
 import { ApexTestResultOutcome, TestResult } from '../../src/tests/types';
-
-const testStartTime = '2020-11-09T18:02:50.000+0000';
-const date = new Date(testStartTime);
-const localStartTime = date.toISOString();
+import { testStartTime, localStartTime } from '../tests/testData';
 
 export const coverageResult: TestResult = {
   summary: {
@@ -522,7 +519,7 @@ export const testResults: TestResult = {
 
 export const junitResult = `<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-    <testsuite name="force.apex" timestamp="2020-11-09T18:02:50.000Z" hostname="https://na139.salesforce.com" tests="16" failures="4"  errors="0"  time="5.46">
+    <testsuite name="force.apex" timestamp="${testStartTime}" hostname="https://na139.salesforce.com" tests="16" failures="4"  errors="0"  time="5.46">
         <properties>
             <property name="failRate" value="13%"/>
             <property name="testsRan" value="16"/>

--- a/packages/apex-node/test/tests/testData.ts
+++ b/packages/apex-node/test/tests/testData.ts
@@ -14,6 +14,7 @@ import {
   SyncTestResult,
   TestResult
 } from '../../src/tests/types';
+import { formatStartTime } from '../../src/utils';
 
 export const syncTestResultSimple: SyncTestResult = {
   apexLogId: '07Lxx00000cxy6YUAQ',
@@ -89,9 +90,8 @@ export const syncTestResultWithFailures: SyncTestResult = {
   totalTime: 87
 };
 
-export const testStartTime = '2020-11-09T18:02:50.000+0000';
-const date = new Date(testStartTime);
-const localStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
+export const testStartTime = '2020-11-09T18:02:50.000Z';
+export const localStartTime = formatStartTime(testStartTime);
 export const testRunId = '707xx0000AGQ3jbQQD';
 
 export const syncResult: TestResult = {


### PR DESCRIPTION
### What does this PR do?

Fixes issue when test start time generated for specific locale (e.g. `en-CA`) resulted in "Invalid time value" error. 

### What issues does this PR fix or reference?

[Unable to get Junit test result format when running Apex tests · Issue #213 · forcedotcom/salesforcedx-apex](https://github.com/forcedotcom/salesforcedx-apex/issues/213)

### Functionality Before

* test start time is initialized to locale time string and then converted to ISO format in JUnit reporter

### Functionality After

* test start time is initialized to ISO format - no conversion happens in JUnit reporter
* test start time is used only in JUnit reporter - hence this change doesn't affect other reporters
