### PR TITLE
fix: added guard against empty coverage

### DIFF
--- a/packages/apex-node/src/tests/syncTests.ts
+++ b/packages/apex-node/src/tests/syncTests.ts
@@ -116,14 +116,18 @@ export class SyncTests {
         apexTestClassIdSet
       );
 
-      result.tests.forEach(item => {
-        const keyCodeCov = `${item.apexClass.id}-${item.methodName}`;
-        const perClassCov = perClassCovMap.get(keyCodeCov);
-        perClassCov.forEach(classCov =>
-          coveredApexClassIdSet.add(classCov.apexClassOrTriggerId)
-        );
-        item.perClassCoverage = perClassCov;
-      });
+      if (perClassCovMap.entries.length > 0) {
+        result.tests.forEach(item => {
+          const keyCodeCov = `${item.apexClass.id}-${item.methodName}`;
+          const perClassCov = perClassCovMap.get(keyCodeCov);
+          if (perClassCov) {
+            perClassCov.forEach(classCov =>
+              coveredApexClassIdSet.add(classCov.apexClassOrTriggerId)
+            );
+            item.perClassCoverage = perClassCov;
+          }
+        });
+      }
 
       const {
         codeCoverageResults,

--- a/packages/apex-node/src/tests/syncTests.ts
+++ b/packages/apex-node/src/tests/syncTests.ts
@@ -116,7 +116,7 @@ export class SyncTests {
         apexTestClassIdSet
       );
 
-      if (perClassCovMap.entries.length > 0) {
+      if (perClassCovMap.size > 0) {
         result.tests.forEach(item => {
           const keyCodeCov = `${item.apexClass.id}-${item.methodName}`;
           const perClassCov = perClassCovMap.get(keyCodeCov);


### PR DESCRIPTION
### What does this PR do?
Adds a guard against perClassCov being referenced when undefined.

### What issues does this PR fix or reference?

@W-10411717@


### Functionality Before

When running the quick launch feature (open Apex test file in editor, and then click "Debug Test"), formatSyncResults() would eventually get called.  Normally, the test file has a reference to the Apex class being tested and actually tests code within the class, and in this scenario, quick launch works.

However, if the test file doesn't test any Apex code (and as such the code coverage is zero), an exception is thrown.


### Functionality After

This change guards against this, and the exception is not thrown, and Quick Launch is allowed to complete.