### PR TITLE
build: update manifest generator to use oclif

### DIFF
--- a/packages/plugin-apex/package.json
+++ b/packages/plugin-apex/package.json
@@ -97,7 +97,7 @@
     "build": "shx rm -rf lib && tsc -b",
     "format": "prettier --config ../../.prettierrc --write './{src,test,scripts}/**/*.{ts,js,json}'",
     "lint": "eslint -c .eslintrc.json --ext .ts ./src ./test",
-    "manifest:generate": "yarn build && oclif-dev manifest",
+    "manifest:generate": "yarn build && oclif manifest",
     "postpack": "shx rm -f oclif.manifest.json",
     "test": "cross-env FORCE_COLOR=true mocha --recursive \"./test/**/*.test.ts\" --full-trace",
     "version": "oclif readme && git add README.md",


### PR DESCRIPTION
### What does this PR do?
I missed updating the generate:manifest build script on the core v3 upgrade which is blocking a publish.  Updated to use oclif instead of oclif-dev. 


