### PR TITLE
chore: bump version to 1.1 since the step failed on the publish job

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/packages/apex-node/package.json
+++ b/packages/apex-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce js library for Apex",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/packages/plugin-apex/package.json
+++ b/packages/plugin-apex/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@salesforce/plugin-apex",
   "description": "Apex commands",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/index.js",
   "dependencies": {
     "@oclif/core": "^1.5.2",
-    "@salesforce/apex-node": "1.0.0",
+    "@salesforce/apex-node": "1.1.0",
     "@salesforce/command": "^5.1.0",
     "@salesforce/core": "^3.23.3",
     "chalk": "^4.1.0",


### PR DESCRIPTION
### What does this PR do?
Bump the version numbers for the package.json & lerna config file in the repo.  Normally would be completed after the plugin-apex publish to npm, but the job failed weirdly here: https://app.circleci.com/pipelines/github/forcedotcom/salesforcedx-apex/1396/workflows/603b52b3-ed3e-4f3d-bcc3-ae0043b8e906/jobs/5672

Following the pattern here from previous publishes: https://github.com/forcedotcom/salesforcedx-apex/commit/637c780ee5924287e1fd465ac5c18490a2fa748b