### PR TITLE
chore: remove GlobalInfo stubs

### DIFF
--- a/packages/apex-node/test/logs/logService.test.ts
+++ b/packages/apex-node/test/logs/logService.test.ts
@@ -93,13 +93,9 @@ describe('Apex Log Service Tests', () => {
 
   beforeEach(async () => {
     sandboxStub = createSandbox();
-    $$.setConfigStubContents('GlobalInfo', {
-      contents: {
-        orgs: {
-          [testData.username]: await testData.getConfig()
-        }
-      }
-    });
+
+    await $$.stubAuths(testData);
+
     // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
     sandboxStub
       .stub(Connection.prototype, 'retrieveMaxApiVersion')

--- a/packages/apex-node/test/tests/payloadUtil.test.ts
+++ b/packages/apex-node/test/tests/payloadUtil.test.ts
@@ -22,13 +22,7 @@ describe('Build async payload', async () => {
   let testService: TestService;
   beforeEach(async () => {
     sandboxStub = createSandbox();
-    $$.setConfigStubContents('GlobalInfo', {
-      contents: {
-        orgs: {
-          [testData.username]: await testData.getConfig()
-        }
-      }
-    });
+    await $$.stubAuths(testData);
     // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
     sandboxStub
       .stub(Connection.prototype, 'retrieveMaxApiVersion')
@@ -271,13 +265,7 @@ describe('Build sync payload', async () => {
   let testSrv: TestService;
   beforeEach(async () => {
     sandboxStub = createSandbox();
-    $$.setConfigStubContents('GlobalInfo', {
-      contents: {
-        orgs: {
-          [testData.username]: await testData.getConfig()
-        }
-      }
-    });
+    await $$.stubAuths(testData);
     // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
     sandboxStub
       .stub(Connection.prototype, 'retrieveMaxApiVersion')

--- a/packages/apex-node/test/tests/syncTests.test.ts
+++ b/packages/apex-node/test/tests/syncTests.test.ts
@@ -54,13 +54,7 @@ describe('Run Apex tests synchronously', () => {
   let formatSpy: SinonSpy;
   beforeEach(async () => {
     sandboxStub = createSandbox();
-    $$.setConfigStubContents('GlobalInfo', {
-      contents: {
-        orgs: {
-          [testData.username]: await testData.getConfig()
-        }
-      }
-    });
+    await $$.stubAuths(testData);
     // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
     sandboxStub
       .stub(Connection.prototype, 'retrieveMaxApiVersion')

--- a/packages/apex-node/test/tests/testService.test.ts
+++ b/packages/apex-node/test/tests/testService.test.ts
@@ -21,13 +21,7 @@ const testData = new MockTestOrgData();
 describe('Apex Test Suites', async () => {
   beforeEach(async () => {
     sandboxStub = createSandbox();
-    $$.setConfigStubContents('GlobalInfo', {
-      contents: {
-        orgs: {
-          [testData.username]: await testData.getConfig()
-        }
-      }
-    });
+    await $$.stubAuths(testData);
     // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
     sandboxStub
       .stub(Connection.prototype, 'retrieveMaxApiVersion')

--- a/packages/apex-node/test/tests/utils.test.ts
+++ b/packages/apex-node/test/tests/utils.test.ts
@@ -18,13 +18,7 @@ const testData = new MockTestOrgData();
 describe('Query Namespaces', async () => {
   beforeEach(async () => {
     sandboxStub = createSandbox();
-    $$.setConfigStubContents('GlobalInfo', {
-      contents: {
-        orgs: {
-          [testData.username]: await testData.getConfig()
-        }
-      }
-    });
+    await $$.stubAuths(testData);
     // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
     sandboxStub
       .stub(Connection.prototype, 'retrieveMaxApiVersion')

--- a/packages/apex-node/test/utils/traceFlags.test.ts
+++ b/packages/apex-node/test/utils/traceFlags.test.ts
@@ -28,13 +28,7 @@ describe('Trace Flags', () => {
 
   beforeEach(async () => {
     sb = createSandbox();
-    $$.setConfigStubContents('GlobalInfo', {
-      contents: {
-        orgs: {
-          [testData.username]: await testData.getConfig()
-        }
-      }
-    });
+    await $$.stubAuths(testData);
     mockConnection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: testData.username


### PR DESCRIPTION
### What does this PR do?

Removes the `GlobalInfo` stubs in preparation of removing `GlobablInfo` (https://github.com/forcedotcom/sfdx-core/pull/606)

### What issues does this PR fix or reference?

@W-11300675@