### PR TITLE
fix: exclude 2 report options

### DIFF
--- a/packages/apex-node/package.json
+++ b/packages/apex-node/package.json
@@ -11,7 +11,8 @@
     "glob": "^8.0.3",
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-report": "^3.0.0",
-    "istanbul-reports": "^3.1.4"
+    "istanbul-reports": "^3.1.4",
+    "@types/istanbul-reports": "^3.0.1"
   },
   "devDependencies": {
     "@salesforce/ts-sinon": "^1.1.2",
@@ -19,7 +20,6 @@
     "@types/chai": "^4",
     "@types/istanbul-lib-coverage": "^2.0.4",
     "@types/istanbul-lib-report": "^3.0.0",
-    "@types/istanbul-reports": "^3.0.1",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",
     "@types/node": "^14",

--- a/packages/apex-node/src/reporters/coverageReporter.ts
+++ b/packages/apex-node/src/reporters/coverageReporter.ts
@@ -31,7 +31,10 @@ const endOfSource = (source: string): number => {
   return 0;
 };
 
-export type CoverageReportFormats = reports.ReportType;
+export type CoverageReportFormats = Exclude<
+  reports.ReportType,
+  'lcov' | 'text-lcov'
+>;
 
 export const DefaultWatermarks: libReport.Watermarks = {
   statements: [50, 75],
@@ -40,7 +43,10 @@ export const DefaultWatermarks: libReport.Watermarks = {
   lines: [50, 75]
 };
 
-export const DefaultReportOptions: Partial<reports.ReportOptions> = {
+export const DefaultReportOptions: Omit<
+  reports.ReportOptions,
+  'lcov' | 'text-lcov'
+> = {
   clover: { file: 'clover.xml', projectRoot: '.' },
   cobertura: { file: 'cobertura.xml', projectRoot: '.' },
   'html-spa': {
@@ -67,7 +73,7 @@ export const DefaultReportOptions: Partial<reports.ReportOptions> = {
 
 export interface CoverageReporterOptions {
   reportFormats?: CoverageReportFormats[];
-  reportOptions?: Partial<typeof DefaultReportOptions>;
+  reportOptions?: typeof DefaultReportOptions;
   watermark?: typeof DefaultWatermarks;
 }
 

--- a/packages/apex-node/src/reporters/coverageReporter.ts
+++ b/packages/apex-node/src/reporters/coverageReporter.ts
@@ -73,7 +73,7 @@ export const DefaultReportOptions: Omit<
 
 export interface CoverageReporterOptions {
   reportFormats?: CoverageReportFormats[];
-  reportOptions?: typeof DefaultReportOptions;
+  reportOptions?: Partial<typeof DefaultReportOptions>;
   watermark?: typeof DefaultWatermarks;
 }
 


### PR DESCRIPTION
### What does this PR do?
our DefaultReportOptions doesn't support 2 of the underlying istanbul report options, so they're now excluded/omitted from the TS exports
types for istanbul-reports have to be a regular (non-dev)Dep so that consumers aren't forced to import it

by narrowing the types to what's allowed, we should be able to get cleaner consumers (see https://github.com/salesforcecli/plugin-source/blob/c242908e3d2a12948629d556f36e3b95b5361b67/src/deployCommand.ts#L214)

### What issues does this PR fix or reference?
@W-11590388@