### PR TITLE
fix: remove listing git tags in deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,6 @@ commands:
     steps:
       - run: *gh-config
       - run:
-          name: Current git tags
-          command: git tag
-      - run:
           name: Create new git tag
           command: |
             PKG_TAG="v$(cat package.json | jq -r .version)"


### PR DESCRIPTION
### What does this PR do?
Remove listing git tags from the deploy step of the build to avoid failing due to waiting for user input. 

### What issues does this PR fix or reference?

fix #299

### Functionality Before

deploy time out 

### Functionality After

deploy success
