### PR TITLE
fix: move commitlint to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",
   "dependencies": {
-    "@commitlint/config-conventional": "^17.2.0",
     "@salesforce/core": "^3.32.12",
     "@types/istanbul-reports": "^3.0.1",
-    "commitlint": "^17.2.0",
     "faye": "1.4.0",
     "glob": "^8.0.3",
     "istanbul-lib-coverage": "^3.2.0",
@@ -17,6 +15,8 @@
     "istanbul-reports": "^3.1.4"
   },
   "devDependencies": {
+    "commitlint": "^17.2.0",
+    "@commitlint/config-conventional": "^17.2.0",
     "@salesforce/ts-sinon": "^1.4.2",
     "@salesforce/ts-types": "1.2.2",
     "@types/chai": "^4",


### PR DESCRIPTION
### What does this PR do?
Moves commitlint to the `devDependencies` object so that these aren't included in the published pkg.

### What issues does this PR fix or reference?

@W-0@
[skip-validate-pr]

### Functionality Before

`commitlint` pkg is included in `sfdx` (`plugin-source` -> `apex-node`):
```
➜  sfdx-cli git:(9600617) npm why commitlint
commitlint@17.3.0
node_modules/commitlint
  commitlint@"^17.2.0" from @salesforce/apex-node@1.6.0
  node_modules/@salesforce/apex-node
    @salesforce/apex-node@"^1.6.0" from @salesforce/plugin-apex@2.2.1
    node_modules/@salesforce/plugin-apex
      @salesforce/plugin-apex@"2.2.1" from the root project
    @salesforce/apex-node@"^1.6.0" from @salesforce/plugin-source@2.5.5
    node_modules/@salesforce/plugin-source
      @salesforce/plugin-source@"2.5.5" from the root project
```

### Functionality After
commitlint not included in pkg.