### PR TITLE
fix(junit): fix locale sensitivity with junit

### DIFF
--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -14,11 +14,11 @@ export function getCurrentTime(): number {
 /**
  * Returns the formatted date and time given the milliseconds in numbers or UTC formatted string
  * @param startTime start time in millisecond numbers or UTC format string
- * @returns date and time formatted for locale
+ * @returns date as ISO string
  */
 export function formatStartTime(startTime: string | number): string {
   const date = new Date(startTime);
-  return `${date.toDateString()} ${date.toLocaleTimeString()}`;
+  return `${date.toISOString()}`;
 }
 
 export function msToSecond(timestamp: string | number): string {

--- a/test/reporters/testResults.ts
+++ b/test/reporters/testResults.ts
@@ -10,7 +10,7 @@ import { ApexTestResultOutcome, TestResult } from '../../src/tests/types';
 
 const testStartTime = '2020-11-09T18:02:50.000+0000';
 const date = new Date(testStartTime);
-const localStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
+const localStartTime = `${date.toISOString()}`;
 
 export const coverageResult: TestResult = {
   summary: {

--- a/test/tests/testData.ts
+++ b/test/tests/testData.ts
@@ -91,7 +91,7 @@ export const syncTestResultWithFailures: SyncTestResult = {
 
 export const testStartTime = '2020-11-09T18:02:50.000+0000';
 const date = new Date(testStartTime);
-const localStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
+const localStartTime = `${date.toISOString()}`;
 export const testRunId = '707xx0000AGQ3jbQQD';
 
 export const syncResult: TestResult = {


### PR DESCRIPTION
closes #323

### What does this PR do?

Changes the start date format util to follow predictable ISO standard

### What issues does this PR fix or reference?

#323

### Functionality Before

Test summary start date was in use locale

### Functionality After

Test summary start date is in ISO format so can be used programmatically later by junit reporter
