### PR TITLE
fix(namespace): incorrect namespacing of test classes

### DIFF
--- a/src/tests/asyncTests.ts
+++ b/src/tests/asyncTests.ts
@@ -359,7 +359,7 @@ export class AsyncTests {
         apexTestClassIdSet.add(item.ApexClass.Id);
         // Can only query the FullName field if a single record is returned, so manually build the field
         item.ApexClass.FullName = item.ApexClass.NamespacePrefix
-          ? `${item.ApexClass.NamespacePrefix}__${item.ApexClass.Name}`
+          ? `${item.ApexClass.NamespacePrefix}.${item.ApexClass.Name}`
           : item.ApexClass.Name;
 
         const diagnostic =

--- a/src/tests/syncTests.ts
+++ b/src/tests/syncTests.ts
@@ -159,7 +159,7 @@ export class SyncTests {
     const apexTestClassIdSet = new Set<string>();
 
     apiTestResult.successes.forEach(item => {
-      const nms = item.namespace ? `${item.namespace}__` : '';
+      const nms = item.namespace ? `${item.namespace}.` : '';
       apexTestClassIdSet.add(item.id);
       testResults.push({
         id: '',

--- a/test/reporters/humanReporter.test.ts
+++ b/test/reporters/humanReporter.test.ts
@@ -20,7 +20,7 @@ describe('Human Reporter Tests', () => {
     const result = reporter.format(testResults, false);
     expect(result).to.not.be.empty;
     expect(result).to.contain(
-      'AnimalLocatorTest.testMissingAnimal                   Fail     System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual:'
+      'AnimalLocatorTest.testMissingAnimal                  Fail     System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual:'
     );
     expect(result).to.contain(
       'Class.AnimalLocatorTest.testMissingAnimal: line 22, column 1'

--- a/test/reporters/testResults.ts
+++ b/test/reporters/testResults.ts
@@ -260,11 +260,11 @@ export const testResults: TestResult = {
         id: '01p3t000003qSzaAAE',
         name: 'tt_UtilControllerTest',
         namespacePrefix: 'trlhdtips',
-        fullName: 'trlhdtips__tt_UtilControllerTest'
+        fullName: 'trlhdtips.tt_UtilControllerTest'
       },
       runTime: 13,
       testTimestamp: '2020-11-09T18:02:51.000+0000',
-      fullName: 'trlhdtips__tt_UtilControllerTest.testGetCurrentUser'
+      fullName: 'trlhdtips.tt_UtilControllerTest.testGetCurrentUser'
     },
     {
       id: '07M3t000003bQwXEAU',
@@ -279,11 +279,11 @@ export const testResults: TestResult = {
         id: '01p3t000003qSzaAAE',
         name: 'tt_UtilControllerTest',
         namespacePrefix: 'trlhdtips',
-        fullName: 'trlhdtips__tt_UtilControllerTest'
+        fullName: 'trlhdtips.tt_UtilControllerTest'
       },
       runTime: 179,
       testTimestamp: '2020-11-09T18:02:51.000+0000',
-      fullName: 'trlhdtips__tt_UtilControllerTest.testResetMyPassword'
+      fullName: 'trlhdtips.tt_UtilControllerTest.testResetMyPassword'
     },
     {
       id: '07M3t000003bQwlEAE',
@@ -357,11 +357,11 @@ export const testResults: TestResult = {
         id: '01p3t000000i4L1AAI',
         name: 'DashboardPalTest',
         namespacePrefix: 'Dashboard_Pal',
-        fullName: 'Dashboard_Pal__DashboardPalTest'
+        fullName: 'Dashboard_Pal.DashboardPalTest'
       },
       runTime: 128,
       testTimestamp: '2020-11-09T18:02:51.000+0000',
-      fullName: 'Dashboard_Pal__DashboardPalTest.testDashboardPal'
+      fullName: 'Dashboard_Pal.DashboardPalTest.testDashboardPal'
     },
     {
       id: '07M3t000003bQx0EAE',
@@ -547,9 +547,9 @@ export const junitResult = `<?xml version="1.0" encoding="UTF-8"?>
         <testcase name="testCallout" classname="AwesomeCalculatorTest" time="0.02">
             <failure message=""></failure>
         </testcase>
-        <testcase name="testGetCurrentUser" classname="trlhdtips__tt_UtilControllerTest" time="0.01">
+        <testcase name="testGetCurrentUser" classname="trlhdtips.tt_UtilControllerTest" time="0.01">
         </testcase>
-        <testcase name="testResetMyPassword" classname="trlhdtips__tt_UtilControllerTest" time="0.18">
+        <testcase name="testResetMyPassword" classname="trlhdtips.tt_UtilControllerTest" time="0.18">
         </testcase>
         <testcase name="testGetCallout" classname="AnimalLocatorTest" time="0.02">
         </testcase>
@@ -558,7 +558,7 @@ export const junitResult = `<?xml version="1.0" encoding="UTF-8"?>
         </testcase>
         <testcase name="testProcessing" classname="LeadProcessorTest" time="2.26">
         </testcase>
-        <testcase name="testDashboardPal" classname="Dashboard_Pal__DashboardPalTest" time="0.13">
+        <testcase name="testDashboardPal" classname="Dashboard_Pal.DashboardPalTest" time="0.13">
         </testcase>
         <testcase name="testCountContacts" classname="AccountProcessorTest" time="0.24">
             <failure message="System.AssertException: Assertion Failed: Incorrect count: Expected: 3, Actual: 2"><![CDATA[Class.AccountProcessorTest.testCountContacts: line 47, column 1]]></failure>

--- a/test/tests/testData.ts
+++ b/test/tests/testData.ts
@@ -126,11 +126,11 @@ export const syncResult: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestApexClass',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestApexClass'
+        fullName: 't3st.TestApexClass'
       },
       runTime: 8,
       testTimestamp: '',
-      fullName: `t3st__TestApexClass.testMethod`
+      fullName: `t3st.TestApexClass.testMethod`
     }
   ]
 };
@@ -168,11 +168,11 @@ export const testResultData: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 8,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog'
+      fullName: 't3st.TestLogger.testLoggerLog'
     }
   ]
 };
@@ -210,11 +210,11 @@ export const missingTimeTestData: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog'
+      fullName: 't3st.TestLogger.testLoggerLog'
     }
   ]
 };
@@ -252,11 +252,11 @@ export const skippedTestData: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog'
+      fullName: 't3st.TestLogger.testLoggerLog'
     }
   ]
 };
@@ -296,11 +296,11 @@ export const diagnosticResult: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog',
+      fullName: 't3st.TestLogger.testLoggerLog',
       diagnostic: {
         className: 'LIFXControllerTest',
         columnNumber: 1,
@@ -331,11 +331,11 @@ export const diagnosticFailure: TestResult = {
         id: '01pxx00000O6tXZQAZ',
         name: 'TestLogger',
         namespacePrefix: 't3st',
-        fullName: 't3st__TestLogger'
+        fullName: 't3st.TestLogger'
       },
       runTime: 0,
       testTimestamp: '3',
-      fullName: 't3st__TestLogger.testLoggerLog',
+      fullName: 't3st.TestLogger.testLoggerLog',
       diagnostic: {
         className: 'LIFXControllerTest',
         compileProblem: '',


### PR DESCRIPTION
closes #296

### What does this PR do?

Correctly applies namespace to namespaced test classes

### What issues does this PR fix or reference?

#296

### Functionality Before

Classes were reporting with namespace and `__` - this is not correct, and resubmitting a test run with that full name fails. Correct namespacing of apex classes is `NS.<class>`

### Functionality After

Correctly return class full names
