### PR TITLE
fix: prefer ISO date format

### DIFF
--- a/src/reporters/junitReporter.ts
+++ b/src/reporters/junitReporter.ts
@@ -9,7 +9,7 @@ import {
   ApexTestResultOutcome,
   TestResult
 } from '../tests/types';
-import { msToSecond } from '../utils';
+import { formatStartTime, msToSecond } from '../utils';
 
 // cli currently has spaces in multiples of four for junit format
 const tab = '    ';
@@ -29,7 +29,7 @@ export class JUnitReporter {
     let output = `<?xml version="1.0" encoding="UTF-8"?>\n`;
     output += `<testsuites>\n`;
     output += `${tab}<testsuite name="force.apex" `;
-    output += `timestamp="${new Date(summary.testStartTime).toISOString()}" `;
+    output += `timestamp="${summary.testStartTime}" `;
     output += `hostname="${summary.hostname}" `;
     output += `tests="${summary.testsRan}" `;
     output += `failures="${summary.failing}"  `;
@@ -59,6 +59,10 @@ export class JUnitReporter {
 
       if (key === 'outcome' && value === 'Passed') {
         value = 'Successful';
+      }
+
+      if (key === 'testStartTime') {
+        value = formatStartTime(value);
       }
 
       junitProperties += `${tab}${tab}${tab}<property name="${key}" value="${value}"/>\n`;

--- a/src/tests/asyncTests.ts
+++ b/src/tests/asyncTests.ts
@@ -234,7 +234,7 @@ export class AsyncTests {
         passRate: calculatePercentage(globalTests.passed, testResults.length),
         failRate: calculatePercentage(globalTests.failed, testResults.length),
         skipRate: calculatePercentage(globalTests.skipped, testResults.length),
-        testStartTime: formatStartTime(testRunSummary.StartTime),
+        testStartTime: formatStartTime(testRunSummary.StartTime, 'ISO'),
         testExecutionTimeInMs: testRunSummary.TestTime ?? 0,
         testTotalTimeInMs: testRunSummary.TestTime ?? 0,
         commandTimeInMs: getCurrentTime() - commandStartTime,

--- a/src/tests/syncTests.ts
+++ b/src/tests/syncTests.ts
@@ -99,7 +99,7 @@ export class SyncTests {
           apiTestResult.numTestsRun
         ),
         skipRate: calculatePercentage(0, apiTestResult.numTestsRun),
-        testStartTime: formatStartTime(startTime),
+        testStartTime: formatStartTime(startTime, 'ISO'),
         testExecutionTimeInMs: apiTestResult.totalTime ?? 0,
         testTotalTimeInMs: apiTestResult.totalTime ?? 0,
         commandTimeInMs: getCurrentTime() - startTime,

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -14,10 +14,18 @@ export function getCurrentTime(): number {
 /**
  * Returns the formatted date and time given the milliseconds in numbers or UTC formatted string
  * @param startTime start time in millisecond numbers or UTC format string
- * @returns date and time formatted for locale
+ * @param format either 'ISO' or 'locale'. Defaults to 'locale' to keep backward compatible.
+ * @returns formatted date and time
  */
-export function formatStartTime(startTime: string | number): string {
+export function formatStartTime(
+  startTime: string | number,
+  format: 'ISO' | 'locale' = 'locale'
+): string {
   const date = new Date(startTime);
+  if (format === 'ISO') {
+    return date.toISOString();
+  }
+
   return `${date.toDateString()} ${date.toLocaleTimeString()}`;
 }
 

--- a/test/reporters/testResults.ts
+++ b/test/reporters/testResults.ts
@@ -10,6 +10,7 @@ import { ApexTestResultOutcome, TestResult } from '../../src/tests/types';
 
 const testStartTime = '2020-11-09T18:02:50.000+0000';
 const date = new Date(testStartTime);
+const isoStartTime = date.toISOString();
 const localStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
 
 export const coverageResult: TestResult = {
@@ -20,7 +21,7 @@ export const coverageResult: TestResult = {
     outcome: 'Completed',
     passRate: '100%',
     skipRate: '0%',
-    testStartTime: localStartTime,
+    testStartTime: isoStartTime,
     testExecutionTimeInMs: 5463,
     testTotalTimeInMs: 5463,
     commandTimeInMs: 6000,
@@ -134,7 +135,7 @@ export const successResult: TestResult = {
     outcome: 'Completed',
     passRate: '100%',
     skipRate: '0%',
-    testStartTime: localStartTime,
+    testStartTime: isoStartTime,
     testExecutionTimeInMs: 5463,
     testTotalTimeInMs: 5463,
     commandTimeInMs: 6000,
@@ -196,7 +197,7 @@ export const testResults: TestResult = {
     outcome: 'Completed',
     passRate: '88%',
     skipRate: '0%',
-    testStartTime: localStartTime,
+    testStartTime: isoStartTime,
     testExecutionTimeInMs: 5463,
     testTotalTimeInMs: 5463,
     commandTimeInMs: 6000,

--- a/test/tests/testData.ts
+++ b/test/tests/testData.ts
@@ -90,8 +90,7 @@ export const syncTestResultWithFailures: SyncTestResult = {
 };
 
 export const testStartTime = '2020-11-09T18:02:50.000+0000';
-const date = new Date(testStartTime);
-const localStartTime = `${date.toDateString()} ${date.toLocaleTimeString()}`;
+const localStartTime = new Date(testStartTime).toISOString();
 export const testRunId = '707xx0000AGQ3jbQQD';
 
 export const syncResult: TestResult = {

--- a/test/utils/dateUtil.test.ts
+++ b/test/utils/dateUtil.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import * as dateUtil from '../../src/utils/dateUtil';
+
+describe('Date Utils', () => {
+  const testStartTime = '2020-11-09T18:02:50.000+0000';
+  const testStartTimeDate = new Date(testStartTime);
+
+  it('should format a date to locale by default', () => {
+    const expectedFormat = `${testStartTimeDate.toDateString()} ${testStartTimeDate.toLocaleTimeString()}`;
+    expect(dateUtil.formatStartTime(testStartTime)).to.equal(expectedFormat);
+  });
+
+  it('should format a date to locale by param', () => {
+    const expectedFormat = `${testStartTimeDate.toDateString()} ${testStartTimeDate.toLocaleTimeString()}`;
+    expect(dateUtil.formatStartTime(testStartTime, 'locale')).to.equal(
+      expectedFormat
+    );
+  });
+
+  it('should format a date to ISO', () => {
+    expect(dateUtil.formatStartTime(testStartTime, 'ISO')).to.equal(
+      testStartTimeDate.toISOString()
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Changes test results start time to be ISO format.  The JUnit reporter still reports the start time property in the locale format.  The `formatStartTime` date utility also has the same default behavior but now also accepts an additional parameter for a date format (ISO or locale).

### What issues does this PR fix or reference?
@W-10226817@
https://github.com/forcedotcom/cli/issues/2220

### Functionality Before
When a language format other than en_US was used to get the ISO time string from a locale specific time string an error would be thrown.

### Functionality After
No error is thrown.  JUnit test start time is still reported in the user locale.  Test results JSON have the start time in ISO format.
