### PR TITLE
fix: support when header is not present

### DIFF
--- a/src/execute/executeService.ts
+++ b/src/execute/executeService.ts
@@ -132,7 +132,7 @@ export class ExecuteService {
     const formattedResponse: ExecuteAnonymousResponse = {
       compiled: execAnonResponse.compiled === 'true',
       success: execAnonResponse.success === 'true',
-      logs: soapResponse[soapEnv][soapHeader].DebuggingInfo.debugLog
+      logs: soapResponse[soapEnv][soapHeader]?.DebuggingInfo.debugLog
     };
 
     if (!formattedResponse.success) {

--- a/src/execute/types.ts
+++ b/src/execute/types.ts
@@ -45,7 +45,7 @@ export const xmlCharMap: { [index: string]: string } = {
 
 export interface SoapResponse {
   [soapEnv]?: {
-    [soapHeader]: { DebuggingInfo: DebuggingInfo };
+    [soapHeader]?: { DebuggingInfo: DebuggingInfo };
     [soapBody]: {
       executeAnonymousResponse: { result: ExecAnonApiResponse };
     };

--- a/test/execute/executeService.test.ts
+++ b/test/execute/executeService.test.ts
@@ -82,6 +82,39 @@ describe('Apex Execute Tests', async () => {
     expect(response).to.eql(expectedResult);
   });
 
+  it('should execute and display successful result when no DebuggingInfo header', async () => {
+    const apexExecute = new ExecuteService(mockConnection);
+    const execAnonResult = {
+      column: -1,
+      line: -1,
+      compiled: 'true',
+      compileProblem: '',
+      exceptionMessage: '',
+      exceptionStackTrace: '',
+      success: 'true'
+    };
+    const soapResponse: SoapResponse = {
+      'soapenv:Envelope': {
+        'soapenv:Body': {
+          executeAnonymousResponse: { result: execAnonResult }
+        }
+      }
+    };
+    const expectedResult: ExecuteAnonymousResponse = {
+      compiled: true,
+      success: true,
+      logs: undefined
+    };
+    sandboxStub
+      .stub(ExecuteService.prototype, 'connectionRequest')
+      .resolves(soapResponse);
+    const response = await apexExecute.executeAnonymous({
+      apexFilePath: 'filepath/to/anonApex/file'
+    });
+
+    expect(response).to.eql(expectedResult);
+  });
+
   it('should execute and display runtime issue in correct format', async () => {
     const apexExecute = new ExecuteService(mockConnection);
     const log =


### PR DESCRIPTION
### What does this PR do?
Updates the type for the header to be optional and handles when it's not there in code.  Adds a unit test.

### What issues does this PR fix or reference?

[Unexpected error while executing anonymous apex. Cannot read properties of undefined (reading 'DebuggingInfo')#2630](https://github.com/forcedotcom/cli/issues/2630)
@W-14750755@

### Functionality Before
Throws `Cannot read properties of undefined (reading 'DebuggingInfo')`

### Functionality After

<insert gif and/or summary>
apex executes without error