### PR TITLE
feat: add per-class coverage infos as test case properties

### DIFF
--- a/src/reporters/junitReporter.ts
+++ b/src/reporters/junitReporter.ts
@@ -81,6 +81,8 @@ export class JUnitReporter {
         testCase.apexClass.fullName
       }" time="${msToSecond(testCase.runTime)}">\n`;
 
+      junitTests += this.buildTestCaseProperties(testCase);
+
       if (
         testCase.outcome === ApexTestResultOutcome.Fail ||
         testCase.outcome === ApexTestResultOutcome.CompileFail
@@ -99,6 +101,36 @@ export class JUnitReporter {
     return junitTests;
   }
 
+  private buildTestCaseProperties(testCase: ApexTestResultData): string {
+    if (!testCase.perClassCoverage || testCase.perClassCoverage.length === 0) {
+      return '';
+    }
+
+    let junitTestProperties = `${tab}${tab}<properties>\n`;
+    Object.entries(testCase.perClassCoverage[0]).forEach(([key, value]) => {
+      if (this.isEmpty(value) || skippedProperties.includes(key)) {
+        return;
+      }
+
+      if (key === 'coverage') {
+        if (value instanceof Object) {
+          let coverageKey: keyof typeof value;
+          for (coverageKey in value) {
+            const coverageValue = value[coverageKey] as number[];
+            junitTestProperties += `${tab}${tab}${tab}<property name="${coverageKey}" value="${coverageValue.join(
+              ','
+            )}"/>\n`;
+          }
+        }
+      } else {
+        junitTestProperties += `${tab}${tab}${tab}<property name="${key}" value="${value}"/>\n`;
+      }
+    });
+    junitTestProperties += `${tab}${tab}</properties>\n`;
+
+    return junitTestProperties;
+  }
+
   private xmlEscape(value: string): string {
     return value
       .replace(/&/g, '&amp;')
@@ -108,7 +140,7 @@ export class JUnitReporter {
       .replace(/'/g, '&apos;');
   }
 
-  private isEmpty(value: string | number): boolean {
+  private isEmpty(value: string | number | object): boolean {
     if (
       value === null ||
       value === undefined ||


### PR DESCRIPTION
### What does this PR do?

This PR adds testcase code coverage infos as properties for the JUnit reporter

### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
