### PR TITLE
fix: unhandled exception when test result is still in progress (#346)

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -30,6 +30,8 @@ export const messages = {
     'Start typing Apex code. Press the Enter key after each line, then press CTRL+D when finished.\n',
   execAnonInputTimeout: 'Timed out while waiting for user input.',
   noTestResultSummary: 'No test results were found for test run %s',
+  noTestResultStatusProcessing:
+    'Apex test results for test run %s but status is still Processing. Please try again.',
   noTestQueueResults: 'No test results were found in the queue for test run %s',
   noAccessTokenFound:
     'No access token could be found for the provided username',

--- a/src/tests/asyncTests.ts
+++ b/src/tests/asyncTests.ts
@@ -168,6 +168,13 @@ export class AsyncTests {
     if (testRunSummaryResults.records.length === 0) {
       throw new Error(nls.localize('noTestResultSummary', testRunId));
     }
+    // Fix issue when ApexTestRunResult is still processing
+    if (
+      testRunSummaryResults.records[0].Status ===
+      ApexTestRunResultStatus.Processing
+    ) {
+      throw new Error(nls.localize('noTestResultStatusProcessing', testRunId));
+    }
 
     if (
       testRunSummaryResults.records[0].Status ===


### PR DESCRIPTION
### What does this PR do?

Fix unhandled exception https://github.com/forcedotcom/salesforcedx-apex/issues/346 

### When we get this error?

- Salesforce Organizations create a an ApexTestRunResult record but the status is still ,,Processing''
- this plugin checks only the statis Aborted,Passed,Completed,Failed,Skipped
- the return value is in this case undefined (optional return parameter)
- in the formatAsyncResults is no check for undefined summarys 

### Solution

- the solution is a new check for the status ,,Processing'' and then throwing a custom exception 
**Apex test results for test run %s but status is still Processing. Please try again.**
- because it make no sense to create a summary without results

