### PR TITLE
feat!: core7 w/ jsforce-node

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,8 +1,9 @@
-# when a github release happens, publish an npm package,
+name: publish
+
 on:
   release:
-    types: [released]
-  # support manual release
+    types: [published]
+  # support manual release in case something goes wrong and needs to be repeated or tested
   workflow_dispatch:
     inputs:
       tag:
@@ -10,9 +11,22 @@ on:
         type: string
         required: true
 jobs:
+  # parses the package.json version and detects prerelease tag (ex: beta from 4.4.4-beta.0)
+  getDistTag:
+    outputs:
+      tag: ${{ steps.distTag.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag  }}
+      - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main
+        id: distTag
+
   npm:
     uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
+    needs: [getDistTag]
     with:
-      ctc: false
+      tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce JS library for Apex",
-  "version": "5.0.0",
+  "version": "5.0.0-beta.1",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce JS library for Apex",
-  "version": "5.0.0",
+  "version": "5.0.0-beta.2",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce JS library for Apex",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce JS library for Apex",
-  "version": "4.0.4",
+  "version": "5.0.0-beta.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",
   "dependencies": {
-    "@salesforce/core": "^6.7.4",
+    "@jsforce/jsforce-node": "^3.1.0",
+    "@salesforce/core": "^7.0.0",
     "@salesforce/kit": "^3.1.0",
     "@types/istanbul-reports": "^3.0.4",
     "faye": "1.4.0",
     "glob": "^10.3.10",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
-    "istanbul-reports": "^3.1.6",
-    "jsforce": "^2.0.0-beta.29"
+    "istanbul-reports": "^3.1.6"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^18.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "lib/src/index.js",
   "dependencies": {
     "@jsforce/jsforce-node": "^3.1.0",
-    "@salesforce/core": "^7.0.0",
+    "@salesforce/core": "^7.2.0",
     "@salesforce/kit": "^3.1.0",
     "@types/istanbul-reports": "^3.0.4",
     "faye": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce JS library for Apex",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",

--- a/src/execute/executeService.ts
+++ b/src/execute/executeService.ts
@@ -19,7 +19,7 @@ import { nls } from '../i18n';
 import { refreshAuth } from '../utils';
 import { encodeBody } from './utils';
 import * as readline from 'readline';
-import { HttpRequest } from 'jsforce';
+import type { HttpRequest } from '@jsforce/jsforce-node';
 import { elapsedTime } from '../utils/elapsedTime';
 
 export class ExecuteService {

--- a/src/execute/executeService.ts
+++ b/src/execute/executeService.ts
@@ -7,13 +7,13 @@
 import { Connection } from '@salesforce/core';
 import { existsSync, readFileSync } from 'fs';
 import {
-  ExecuteAnonymousResponse,
+  action,
   ApexExecuteOptions,
-  SoapResponse,
-  soapEnv,
+  ExecuteAnonymousResponse,
   soapBody,
+  soapEnv,
   soapHeader,
-  action
+  SoapResponse
 } from './types';
 import { nls } from '../i18n';
 import { refreshAuth } from '../utils';
@@ -121,14 +121,12 @@ export class ExecuteService {
       'content-type': 'text/xml',
       soapaction: action
     };
-    const request: HttpRequest = {
+    return {
       method: 'POST',
       url: postEndpoint,
       body,
       headers: requestHeaders
     };
-
-    return request;
   }
 
   @elapsedTime()
@@ -170,6 +168,6 @@ export class ExecuteService {
   public async connectionRequest(
     requestData: HttpRequest
   ): Promise<SoapResponse> {
-    return (await this.connection.request(requestData)) as SoapResponse;
+    return this.connection.request(requestData);
   }
 }

--- a/src/logs/logService.ts
+++ b/src/logs/logService.ts
@@ -14,17 +14,12 @@ import {
 import { Duration } from '@salesforce/kit';
 import { AnyJson } from '@salesforce/ts-types';
 import {
-  LOG_TIMER_LENGTH_MINUTES,
   LISTENER_ABORTED_ERROR_NAME,
+  LOG_TIMER_LENGTH_MINUTES,
   MAX_NUM_LOGS,
   STREAMING_LOG_TOPIC
 } from './constants';
-import {
-  ApexLogGetOptions,
-  LogQueryResult,
-  LogRecord,
-  LogResult
-} from './types';
+import { ApexLogGetOptions, LogRecord, LogResult } from './types';
 import * as path from 'path';
 import { nls } from '../i18n';
 import { createFile } from '../utils';
@@ -97,7 +92,7 @@ export class LogService {
   public async getLogById(logId: string): Promise<LogResult> {
     const baseUrl = this.connection.tooling._baseUrl();
     const url = `${baseUrl}/sobjects/ApexLog/${logId}/Body`;
-    const response = (await this.connection.tooling.request(url)) as AnyJson;
+    const response = await this.connection.tooling.request<AnyJson>(url);
     return { log: response.toString() || '' };
   }
 
@@ -118,10 +113,8 @@ export class LogService {
       apexLogQuery += ` LIMIT ${numberOfLogs}`;
     }
 
-    const response = (await this.connection.tooling.query(
-      apexLogQuery
-    )) as LogQueryResult;
-    return response.records as LogRecord[];
+    return (await this.connection.tooling.query<LogRecord>(apexLogQuery))
+      .records;
   }
 
   @elapsedTime()

--- a/src/streaming/streamingClient.ts
+++ b/src/streaming/streamingClient.ts
@@ -20,11 +20,13 @@ import {
   ApexTestProgressValue,
   ApexTestQueueItem,
   ApexTestQueueItemRecord,
-  ApexTestQueueItemStatus
+  ApexTestQueueItemStatus,
+  TestRunIdResult
 } from '../tests/types';
+import { Duration } from '@salesforce/kit';
 
 const TEST_RESULT_CHANNEL = '/systemTopic/TestResult';
-const DEFAULT_STREAMING_TIMEOUT_MS = 14400;
+export const DEFAULT_STREAMING_TIMEOUT_SEC = 14400;
 
 export interface AsyncTestRun {
   runId: string;
@@ -44,9 +46,8 @@ export class StreamingClient {
   // that is exported from jsforce.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private client: any;
-  private conn: Connection;
+  private readonly conn: Connection;
   private progress?: Progress<ApexTestProgressValue>;
-  private apiVersion = '36.0';
   public subscribedTestRunId: string;
   private subscribedTestRunIdDeferred = new Deferred<string>();
   public get subscribedTestRunIdPromise(): Promise<string> {
@@ -74,7 +75,7 @@ export class StreamingClient {
     this.progress = progress;
     const streamUrl = this.getStreamURL(this.conn.instanceUrl);
     this.client = new Client(streamUrl, {
-      timeout: DEFAULT_STREAMING_TIMEOUT_MS
+      timeout: DEFAULT_STREAMING_TIMEOUT_SEC
     });
 
     this.client.on('transport:up', () => {
@@ -166,10 +167,21 @@ export class StreamingClient {
   @elapsedTime()
   public async subscribe(
     action?: () => Promise<string>,
-    testRunId?: string
-  ): Promise<AsyncTestRun> {
+    testRunId?: string,
+    timeout?: Duration
+  ): Promise<AsyncTestRun | TestRunIdResult> {
     return new Promise((subscriptionResolve, subscriptionReject) => {
       let intervalId: NodeJS.Timeout;
+      // start timeout
+      setTimeout(
+        () => {
+          this.disconnect();
+          clearInterval(intervalId);
+          subscriptionResolve({ testRunId });
+        },
+        timeout?.milliseconds ?? DEFAULT_STREAMING_TIMEOUT_SEC * 1000
+      );
+
       try {
         this.client.subscribe(
           TEST_RESULT_CHANNEL,

--- a/src/streaming/streamingClient.ts
+++ b/src/streaming/streamingClient.ts
@@ -173,7 +173,7 @@ export class StreamingClient {
     return new Promise((subscriptionResolve, subscriptionReject) => {
       let intervalId: NodeJS.Timeout;
       // start timeout
-      setTimeout(
+      const timeoutId = setTimeout(
         () => {
           this.disconnect();
           clearInterval(intervalId);
@@ -191,6 +191,7 @@ export class StreamingClient {
             if (result) {
               this.disconnect();
               clearInterval(intervalId);
+              clearTimeout(timeoutId);
               subscriptionResolve({
                 runId: this.subscribedTestRunId,
                 queueItem: result
@@ -211,6 +212,7 @@ export class StreamingClient {
                   if (result) {
                     this.disconnect();
                     clearInterval(intervalId);
+                    clearTimeout(timeoutId);
                     subscriptionResolve({
                       runId: this.subscribedTestRunId,
                       queueItem: result
@@ -222,6 +224,7 @@ export class StreamingClient {
             .catch((e) => {
               this.disconnect();
               clearInterval(intervalId);
+              clearTimeout(timeoutId);
               subscriptionReject(e);
             });
         } else {
@@ -234,6 +237,7 @@ export class StreamingClient {
               if (result) {
                 this.disconnect();
                 clearInterval(intervalId);
+                clearTimeout(timeoutId);
                 subscriptionResolve({
                   runId: this.subscribedTestRunId,
                   queueItem: result
@@ -244,6 +248,7 @@ export class StreamingClient {
         }
       } catch (e) {
         this.disconnect();
+        clearTimeout(timeoutId);
         clearInterval(intervalId);
         subscriptionReject(e);
       }

--- a/src/tests/asyncTests.ts
+++ b/src/tests/asyncTests.ts
@@ -30,7 +30,7 @@ import { calculatePercentage, queryAll } from './utils';
 import * as util from 'util';
 import { QUERY_RECORD_LIMIT } from './constants';
 import { CodeCoverage } from './codeCoverage';
-import { HttpRequest } from 'jsforce';
+import type { HttpRequest } from '@jsforce/jsforce-node';
 import { isValidTestRunID } from '../narrowing';
 
 const finishedStatuses = [

--- a/src/tests/asyncTests.ts
+++ b/src/tests/asyncTests.ts
@@ -30,8 +30,8 @@ import { calculatePercentage, queryAll } from './utils';
 import * as util from 'util';
 import { QUERY_RECORD_LIMIT } from './constants';
 import { CodeCoverage } from './codeCoverage';
-import type { HttpRequest } from '@jsforce/jsforce-node';
 import { isValidTestRunID } from '../narrowing';
+import { Duration } from '@salesforce/kit';
 
 const finishedStatuses = [
   ApexTestRunResultStatus.Aborted,
@@ -64,7 +64,8 @@ export class AsyncTests {
     codeCoverage = false,
     exitOnTestRunId = false,
     progress?: Progress<ApexTestProgressValue>,
-    token?: CancellationToken
+    token?: CancellationToken,
+    timeout?: Duration
   ): Promise<TestResult | TestRunIdResult> {
     try {
       const sClient = new StreamingClient(this.connection, progress);
@@ -87,8 +88,17 @@ export class AsyncTests {
       if (token && token.isCancellationRequested) {
         return null;
       }
+      const asyncRunResult = await sClient.subscribe(
+        undefined,
+        testRunId,
+        timeout
+      );
 
-      const asyncRunResult = await sClient.subscribe(undefined, testRunId);
+      if ('testRunId' in asyncRunResult) {
+        // timeout, return the id
+        return { testRunId };
+      }
+
       const runResult = await this.checkRunStatus(asyncRunResult.runId);
       return await this.formatAsyncResults(
         asyncRunResult,
@@ -124,7 +134,9 @@ export class AsyncTests {
       if (runResult.testsComplete) {
         queueItem = await sClient.handler(undefined, testRunId);
       } else {
-        queueItem = (await sClient.subscribe(undefined, testRunId)).queueItem;
+        queueItem = (
+          (await sClient.subscribe(undefined, testRunId)) as AsyncTestRun
+        ).queueItem;
         runResult = await this.checkRunStatus(testRunId);
       }
 
@@ -426,17 +438,14 @@ export class AsyncTests {
   ): () => Promise<string> {
     const requestTestRun = async (): Promise<string> => {
       const url = `${this.connection.tooling._baseUrl()}/runTestsAsynchronous`;
-      const request: HttpRequest = {
-        method: 'POST',
-        url,
-        body: JSON.stringify(options),
-        headers: { 'content-type': 'application/json' }
-      };
 
       try {
-        const testRunId = (await this.connection.tooling.request(
-          request
-        )) as string;
+        const testRunId = await this.connection.tooling.request<string>({
+          method: 'POST',
+          url,
+          body: JSON.stringify(options),
+          headers: { 'content-type': 'application/json' }
+        });
         return Promise.resolve(testRunId);
       } catch (e) {
         return Promise.reject(e);

--- a/src/tests/asyncTests.ts
+++ b/src/tests/asyncTests.ts
@@ -57,6 +57,7 @@ export class AsyncTests {
    * @param exitOnTestRunId should not wait for test run to complete, return test run id immediately
    * @param progress progress reporter
    * @param token cancellation token
+   * @param timeout Duration to wait before returning a TestRunIdResult
    */
   @elapsedTime()
   public async runTests(

--- a/src/tests/syncTests.ts
+++ b/src/tests/syncTests.ts
@@ -19,7 +19,7 @@ import {
   TestResult
 } from './types';
 import { calculatePercentage } from './utils';
-import { HttpRequest } from 'jsforce';
+import type { HttpRequest } from '@jsforce/jsforce-node';
 import { elapsedTime } from '../utils/elapsedTime';
 
 export class SyncTests {

--- a/src/tests/testService.ts
+++ b/src/tests/testService.ts
@@ -36,6 +36,7 @@ import { JSONStringifyStream, TestResultStringifyStream } from '../streaming';
 import { CodeCoverageStringifyStream } from '../streaming/codeCoverageStringifyStream';
 import { elapsedTime } from '../utils';
 import { isTestResult, isValidApexClassID } from '../narrowing';
+import { Duration } from '@salesforce/kit';
 
 export class TestService {
   private readonly connection: Connection;
@@ -209,14 +210,16 @@ export class TestService {
     codeCoverage = false,
     immediatelyReturn = false,
     progress?: Progress<ApexTestProgressValue>,
-    token?: CancellationToken
+    token?: CancellationToken,
+    timeout?: Duration
   ): Promise<TestResult | TestRunIdResult> {
     return await this.asyncService.runTests(
       options,
       codeCoverage,
       immediatelyReturn,
       progress,
-      token
+      token,
+      timeout
     );
   }
 

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -7,7 +7,7 @@
 
 import { Connection } from '@salesforce/core';
 import { NamespaceInfo } from './types';
-import { QueryResult } from 'jsforce';
+import type { QueryResult } from '@jsforce/jsforce-node';
 
 export function calculatePercentage(dividend: number, divisor: number): string {
   let percentage = '0%';

--- a/src/utils/authUtil.ts
+++ b/src/utils/authUtil.ts
@@ -7,7 +7,7 @@
 import { Connection } from '@salesforce/core';
 import { JsonCollection } from '@salesforce/ts-types';
 import { xmlCharMap } from './types';
-import { HttpRequest } from 'jsforce';
+import type { HttpRequest } from '@jsforce/jsforce-node';
 
 export async function refreshAuth(
   connection: Connection

--- a/test/execute/executeService.test.ts
+++ b/test/execute/executeService.test.ts
@@ -8,8 +8,8 @@
 import { Connection } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { assert, expect } from 'chai';
-import * as fs from 'fs';
-import * as readline from 'readline';
+import fs from 'node:fs';
+import readline from 'readline';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { ExecuteService } from '../../src/execute';
 import { nls } from '../../src/i18n';

--- a/test/execute/executeService.test.ts
+++ b/test/execute/executeService.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { assert, expect } from 'chai';
 import * as fs from 'fs';
 import * as readline from 'readline';

--- a/test/logs/logService.test.ts
+++ b/test/logs/logService.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { AuthInfo, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { expect, assert } from 'chai';
 import * as fs from 'fs';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';

--- a/test/logs/logService.test.ts
+++ b/test/logs/logService.test.ts
@@ -8,11 +8,11 @@
 import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { expect, assert } from 'chai';
-import * as fs from 'fs';
+import fs from 'fs';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { LogService } from '../../src/logs/logService';
-import * as path from 'path';
-import * as stream from 'stream';
+import path from 'path';
+import stream from 'stream';
 import { LogQueryResult, LogRecord, LogResult } from '../../src/logs/types';
 
 const logRecords: LogRecord[] = [

--- a/test/streaming/streamingClient.test.ts
+++ b/test/streaming/streamingClient.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../src/tests/types';
 import { nls } from '../../src/i18n';
 import { EventEmitter } from 'events';
+import { Duration } from '@salesforce/kit';
 
 // The type defined in jsforce doesn't have all Faye client methods.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -507,6 +508,32 @@ describe('Streaming API Client', () => {
 
     await Promise.resolve();
     assert.calledOnce(mockToolingQuery);
+  });
+
+  it('should return the run id, disconnect and clear interval on timeout', async () => {
+    sandboxStub.stub(ApexFayeClient.prototype, 'subscribe');
+    const disconnectStub = sandboxStub.stub(
+      ApexFayeClient.prototype,
+      'disconnect'
+    );
+    const mockRunId = '707xx0000AGQ3jbQQD';
+
+    const setIntervalStub = sandboxStub.stub(global, 'setInterval');
+    setIntervalStub.callsFake((callback: Function) => callback.call(null));
+    const clearIntervalStub = sandboxStub.stub(global, 'clearInterval');
+
+    const streamClient = new StreamingClient(mockConnection);
+    const result = await streamClient.subscribe(
+      () => Promise.resolve(mockRunId),
+      mockRunId,
+      Duration.milliseconds(10)
+    );
+
+    expect(result).to.eql({
+      testRunId: mockRunId
+    });
+    assert.calledOnce(disconnectStub);
+    assert.calledOnce(clearIntervalStub);
   });
 
   it('should return the results, disconnect and clear interval on test completion', async () => {

--- a/test/streaming/streamingClient.test.ts
+++ b/test/streaming/streamingClient.test.ts
@@ -560,6 +560,7 @@ describe('Streaming API Client', () => {
     const setIntervalStub = sandboxStub.stub(global, 'setInterval');
     setIntervalStub.callsFake((callback: Function) => callback.call(null));
     const clearIntervalStub = sandboxStub.stub(global, 'clearInterval');
+    const clearTimeoutStub = sandboxStub.stub(global, 'clearTimeout');
 
     const streamClient = new StreamingClient(mockConnection);
     const result = await streamClient.subscribe(() =>
@@ -573,5 +574,6 @@ describe('Streaming API Client', () => {
     assert.calledOnce(mockToolingQuery);
     assert.calledOnce(disconnectStub);
     assert.calledOnce(clearIntervalStub);
+    assert.calledOnce(clearTimeoutStub);
   });
 });

--- a/test/streaming/streamingClient.test.ts
+++ b/test/streaming/streamingClient.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { assert, createSandbox, SinonSandbox } from 'sinon';
 import { StreamingClient } from '../../src/streaming';
 import { Deferred } from '../../src/streaming/streamingClient';

--- a/test/tests/asyncTests.test.ts
+++ b/test/tests/asyncTests.test.ts
@@ -7,7 +7,7 @@
 import * as sinon from 'sinon';
 import { Connection, Logger } from '@salesforce/core';
 import { elapsedTime } from '../../src/utils';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { assert, expect } from 'chai';
 import {
   assert as sinonAssert,

--- a/test/tests/asyncTests.test.ts
+++ b/test/tests/asyncTests.test.ts
@@ -4,12 +4,11 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import * as sinon from 'sinon';
 import { Connection, Logger } from '@salesforce/core';
 import { elapsedTime } from '../../src/utils';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { assert, expect } from 'chai';
-import {
+import sinon, {
   assert as sinonAssert,
   createSandbox,
   SinonSandbox,
@@ -57,8 +56,8 @@ import {
   skippedTestData
 } from '../testData';
 import { join } from 'path';
-import * as stream from 'stream';
-import * as fs from 'fs';
+import stream from 'stream';
+import fs from 'fs';
 import * as diagnosticUtil from '../../src/tests/diagnosticUtil';
 import * as utils from '../../src/tests/utils';
 import { AsyncTests } from '../../src/tests/asyncTests';

--- a/test/tests/codeCoverage.test.ts
+++ b/test/tests/codeCoverage.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { CodeCoverage } from '../../src/tests/codeCoverage';

--- a/test/tests/payloadUtil.test.ts
+++ b/test/tests/payloadUtil.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { AuthInfo, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { assert, createSandbox, SinonSandbox } from 'sinon';
 import { nls } from '../../src/i18n';

--- a/test/tests/syncTests.test.ts
+++ b/test/tests/syncTests.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { AuthInfo, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonSpy, SinonStub } from 'sinon';
 import * as fs from 'fs';

--- a/test/tests/syncTests.test.ts
+++ b/test/tests/syncTests.test.ts
@@ -9,8 +9,8 @@ import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonSpy, SinonStub } from 'sinon';
-import * as fs from 'fs';
-import * as stream from 'stream';
+import fs from 'fs';
+import stream from 'stream';
 import { join } from 'path';
 import { SyncTestConfiguration, TestService } from '../../src/tests';
 import {

--- a/test/tests/testService.test.ts
+++ b/test/tests/testService.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { AuthInfo, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { fail } from 'assert';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub, spy } from 'sinon';

--- a/test/tests/utils.test.ts
+++ b/test/tests/utils.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { AuthInfo, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox } from 'sinon';
 import * as utils from '../../src/tests/utils';

--- a/test/utils/fileSystemHandler.test.ts
+++ b/test/utils/fileSystemHandler.test.ts
@@ -8,7 +8,7 @@ import * as fsUtil from '../../src/utils/fileSystemHandler';
 import { createSandbox, SinonStub } from 'sinon';
 import { expect } from 'chai';
 import { join } from 'path';
-import * as fs from 'fs';
+import fs from 'fs';
 
 const sb = createSandbox();
 

--- a/test/utils/traceFlags.test.ts
+++ b/test/utils/traceFlags.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { fail } from 'assert';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "Node16",
     "target": "ES2022",
     "lib": ["ES2020", "dom"],
     "sourceMap": true,
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node16",
     "noImplicitAny": true,
     "rootDir": ".",
     "outDir": "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,10 +546,10 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
-"@salesforce/core@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.0.0.tgz#f680cff11192cdf939067959908613365bf4bf2e"
-  integrity sha512-yoZFx1jC75D4uGLGRNKIzxS2W+AHExFD4wT9whLox1c2B48nxZjaEB2zB3d9dBtoZcVD5KI5AvmPGJ7eyPnLHA==
+"@salesforce/core@^7.2.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.0.tgz#2ad3dfccb1ef0eb2e65b49b655e39748002bbc13"
+  integrity sha512-c/gZLvKFHvgAv/Gyd4LjGGQykvGLn67QtCmdT7Hnm57bTDZoyr7XJXcaI+ILN0NO47guG1tEWP5eBvAi+u2DNA==
   dependencies:
     "@jsforce/jsforce-node" "^3.1.0"
     "@salesforce/kit" "^3.1.0"
@@ -748,7 +748,14 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
 
-"@types/node@*", "@types/node@^18", "@types/node@^18.11.9", "@types/node@^18.15.3":
+"@types/node@*", "@types/node@^18", "@types/node@^18.11.9":
+  version "18.19.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.3.tgz#e4723c4cb385641d61b983f6fe0b716abd5f8fc0"
+  integrity sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^18.15.3":
   version "18.19.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.31.tgz#b7d4a00f7cb826b60a543cebdbda5d189aaecdcd"
   integrity sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,21 +160,6 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.5.tgz#37dee97c4752af148e1d38c34b856b2507660563"
   integrity sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==
 
-"@babel/runtime-corejs3@^7.12.5":
-  version "7.18.0"
-  resolved "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.0.tgz"
-  integrity sha512-G5FaGZOWORq9zthDjIrjib5XlcddeqLbIiDO3YQsut6j7aGf76xn0umUC/pA6+nApk3hQJF4JzLzg5PCl6ewJg==
-  dependencies:
-    core-js-pure "^3.20.2"
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.12.5":
-  version "7.18.0"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz"
-  integrity sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -503,6 +488,26 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsforce/jsforce-node@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.1.0.tgz#7f1b4ba60c0c84b870af8e43d713907b10ed8152"
+  integrity sha512-xsn6Qj36YyhG7uCL9DOswZhqN/OVIpXm5s8AWD7V9hSJfp5ReebEsjT7a52ztEMmkUAYjWvZC5alBJr7jJCJig==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    "@types/node" "^18.15.3"
+    abort-controller "^3.0.0"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.4.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    fs-extra "^8.1.0"
+    https-proxy-agent "^5.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    strip-ansi "^6.0.0"
+    xml2js "^0.6.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -541,21 +546,20 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
-"@salesforce/core@^6.7.4":
-  version "6.7.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.7.4.tgz#7afb6b37a391f4af4473257e4b2fbafe9a0f24ed"
-  integrity sha512-zB/dnhz/x9Kw6r1Ub6Uawc1zFHF84RfERv3UTcdZPtaaEodUQpZSu9avAUaGGEufWaNjPK+RRSgeZ1tG67g8qg==
+"@salesforce/core@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.0.0.tgz#f680cff11192cdf939067959908613365bf4bf2e"
+  integrity sha512-yoZFx1jC75D4uGLGRNKIzxS2W+AHExFD4wT9whLox1c2B48nxZjaEB2zB3d9dBtoZcVD5KI5AvmPGJ7eyPnLHA==
   dependencies:
+    "@jsforce/jsforce-node" "^3.1.0"
     "@salesforce/kit" "^3.1.0"
-    "@salesforce/schemas" "^1.6.1"
+    "@salesforce/schemas" "^1.7.0"
     "@salesforce/ts-types" "^2.0.9"
-    "@types/semver" "^7.5.8"
     ajv "^8.12.0"
     change-case "^4.1.2"
     faye "^1.4.0"
     form-data "^4.0.0"
     js2xmlparser "^4.0.1"
-    jsforce "^2.0.0-beta.29"
     jsonwebtoken "9.0.2"
     jszip "3.10.1"
     pino "^8.19.0"
@@ -573,10 +577,10 @@
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"
 
-"@salesforce/schemas@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
-  integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
+"@salesforce/schemas@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.7.0.tgz#b7e0af3ee414ae7160bce351c0184d77ccb98fe3"
+  integrity sha512-Z0PiCEV55khm0PG+DsnRYCjaDmacNe3HDmsoSm/CSyYvJJm+D5vvkHKN9/PKD/gaRe8XAU836yfamIYFblLINw==
 
 "@salesforce/ts-sinon@^1.4.19":
   version "1.4.19"
@@ -593,6 +597,11 @@
   integrity sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==
   dependencies:
     tslib "^2.6.2"
+
+"@sindresorhus/is@^4":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -739,17 +748,12 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
 
-"@types/node@*", "@types/node@^18", "@types/node@^18.11.9":
-  version "18.19.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.3.tgz#e4723c4cb385641d61b983f6fe0b716abd5f8fc0"
-  integrity sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==
+"@types/node@*", "@types/node@^18", "@types/node@^18.11.9", "@types/node@^18.15.3":
+  version "18.19.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.31.tgz#b7d4a00f7cb826b60a543cebdbda5d189aaecdcd"
+  integrity sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/node@^12.19.9":
-  version "12.20.52"
-  resolved "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz"
-  integrity sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -760,11 +764,6 @@
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.7.tgz#326f5fdda70d13580777bcaa1bc6fa772a5aef0e"
   integrity sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==
-
-"@types/semver@^7.5.8":
-  version "7.5.8"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
-  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
 "@types/sinon@^17.0.1":
   version "17.0.2"
@@ -1440,11 +1439,6 @@ commander@11.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
-commander@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
 comment-parser@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.1.tgz#bdafead37961ac079be11eb7ec65c4d021eaf9cc"
@@ -1544,16 +1538,6 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-core-js-pure@^3.20.2:
-  version "3.22.5"
-  resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.5.tgz"
-  integrity sha512-8xo9R00iYD7TcV7OrC98GwxiUEAabVWO3dix+uyWjnYrx9fyASLlIX+f/3p5dW5qByaP2bcZ8X/T47s55et/tA==
-
-core-js@^3.6.4:
-  version "3.22.5"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz"
-  integrity sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==
-
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
@@ -1602,15 +1586,15 @@ csprng@*:
   dependencies:
     sequin "*"
 
-csv-parse@^4.8.2:
-  version "4.16.3"
-  resolved "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz"
-  integrity sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==
+csv-parse@^5.5.2:
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.5.5.tgz#68a271a9092877b830541805e14c8a80e6a22517"
+  integrity sha512-erCk7tyU3yLWAhk6wvKxnyPtftuy/6Ak622gOO7BCJ05+TYffnPCJF905wmOQm+BpkX54OdAl8pveJwUdpnCXQ==
 
-csv-stringify@^5.3.4:
-  version "5.6.5"
-  resolved "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz"
-  integrity sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==
+csv-stringify@^6.4.4:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-6.4.6.tgz#9ccf87cb8b017c96673a9fa061768c8ba83e8b98"
+  integrity sha512-h2V2XZ3uOTLilF5dPIptgUfN/o2ia/80Ie0Lly18LAnw5s8Eb7kt8rfxSUy24AztJZas9f6DPZpVlzDUtFt/ag==
 
 cz-conventional-changelog@3.3.0, cz-conventional-changelog@^3.3.0:
   version "3.3.0"
@@ -2621,25 +2605,6 @@ inquirer@8.2.4:
     through "^2.3.6"
     wrap-ansi "^7.0.0"
 
-inquirer@^7.0.0:
-  version "7.3.3"
-  resolved "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz"
-  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.0"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.19"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.6.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
 interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz"
@@ -2789,7 +2754,7 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^2.1.1, is-wsl@^2.2.0:
+is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -2926,32 +2891,6 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
-
-jsforce@^2.0.0-beta.29:
-  version "2.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.29.tgz#0b59b026eb0b90dfb199a53656af32a4c8acc48f"
-  integrity sha512-Fq7xjOYOikyozZZDQNTfzsAdhcO0rUXwtavsjM+cCYUFiCMVOJJavgco303zOsJk3v8sdAYnGgHyKckLIhnyAg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@babel/runtime-corejs3" "^7.12.5"
-    "@types/node" "^12.19.9"
-    abort-controller "^3.0.0"
-    base64url "^3.0.1"
-    commander "^4.0.1"
-    core-js "^3.6.4"
-    csv-parse "^4.8.2"
-    csv-stringify "^5.3.4"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    fs-extra "^8.1.0"
-    https-proxy-agent "^5.0.0"
-    inquirer "^7.0.0"
-    multistream "^3.1.0"
-    node-fetch "^2.6.1"
-    open "^7.0.0"
-    regenerator-runtime "^0.13.3"
-    strip-ansi "^6.0.0"
-    xml2js "^0.5.0"
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
@@ -3214,7 +3153,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3661,14 +3600,6 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-open@^7.0.0:
-  version "7.4.2"
-  resolved "https://registry.npmjs.org/open/-/open-7.4.2.tgz"
-  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
-  dependencies:
-    is-docker "^2.0.0"
-    is-wsl "^2.1.1"
-
 open@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/open/-/open-9.1.0.tgz#684934359c90ad25742f5a26151970ff8c6c80b6"
@@ -4101,11 +4032,6 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
-  version "0.13.9"
-  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
-
 release-zalgo@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz"
@@ -4219,13 +4145,6 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.0:
-  version "6.6.7"
-  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
-
 rxjs@^7.5.5:
   version "7.5.7"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz"
@@ -4273,7 +4192,7 @@ secure-json-parse@^2.4.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.5.4, semver@^7.3.4, semver@^7.5.3, semver@^7.5.4:
+semver@7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -4285,7 +4204,7 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.6.0:
+semver@^7.3.4, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
@@ -4738,11 +4657,6 @@ ts-retry-promise@^0.7.1:
   resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz#176d6eee6415f07b6c7c286d3657355e284a6906"
   integrity sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==
 
-tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.0.3, tslib@^2.1.0, tslib@^2.6.0, tslib@^2.6.1, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
@@ -5004,10 +4918,10 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-xml2js@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
-  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"


### PR DESCRIPTION
> this is published as a beta npm package.  Set the pjson `version` property back where it belongs before merging

now with 80% less jsforce bloat!

use top-levle export for testSetup (requires some tsconfig changes to support node16 module resolution, which changes `import *` stuff
@W-15387805@