### PR TITLE
Revert "chore(release): 4.0.4 [skip ci]"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce JS library for Apex",
-  "version": "4.0.4",
+  "version": "4.0.3",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "lib/src/index.js",


### PR DESCRIPTION
This reverts commit 1b49da3fc129a01553771d0e074ebefd4328408c to make the latest version of @salesforce/apex-node v4.0.3.