### PR TITLE
fix: no dangling comma is included in result

### DIFF
--- a/src/streaming/testResultStringifyStream.ts
+++ b/src/streaming/testResultStringifyStream.ts
@@ -68,13 +68,13 @@ export class TestResultStringifyStream extends Readable {
       }
     });
 
-    this.push('],');
+    this.push(']');
   }
 
   @elapsedTime()
   buildCodeCoverage(): void {
     if (this.testResult.codecoverage) {
-      this.push('"codecoverage":[');
+      this.push(',"codecoverage":[');
       const numberOfCodeCoverage = this.testResult.codecoverage.length - 1;
       this.testResult.codecoverage.forEach((coverage, index) => {
         const { coveredLines, uncoveredLines, ...theRest } = coverage;

--- a/test/streaming/testResultStringifyStream.test.ts
+++ b/test/streaming/testResultStringifyStream.test.ts
@@ -180,7 +180,7 @@ describe('TestResultStringifyStream', () => {
 
     stream._read();
   });
-  it('should transform TestResult into a JSON string', (done) => {
+  it('should transform TestResult into a JSON string with tests and coverage both present', (done) => {
     let output = '';
     const testsWithCoverage = structuredClone(tests);
     testsWithCoverage[0].perClassCoverage = [perClassCoverageData[0]];


### PR DESCRIPTION
@W-15530915@
Fix the edge case to prevent dangling comma when tests are not run with coverage

The vscode-core extension has a setting that lets the cutomer choose if the do not want code coverage calculated when running apex tests. With no coverage data present the code that produces the json results, which are used to highlight coverage in vscode, was inserting a comma after the test results, resulting in an invalid json file.

This fix properly handless tests run with no code coverage present.