### PR TITLE
ci: setup ext NUTs for apex-node

### DIFF
--- a/.github/workflows/testCommitExceptMain.yml
+++ b/.github/workflows/testCommitExceptMain.yml
@@ -19,7 +19,5 @@ jobs:
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-apex'
       command: 'yarn test:nuts'
       os: ${{ matrix.os }}
-      preSwapCommands: 'yarn upgrade @salesforce/core; npx yarn-deduplicate; yarn install'
-      preExternalBuildCommands: 'npm why @salesforce/core --json'
       useCache: false
     secrets: inherit

--- a/.github/workflows/testCommitExceptMain.yml
+++ b/.github/workflows/testCommitExceptMain.yml
@@ -6,3 +6,19 @@ on:
 jobs:
   unit-tests:
     uses: salesforcecli/github-workflows/.github/workflows/unitTest.yml@main
+  xNuts:
+    needs: unit-tests
+    uses: salesforcecli/github-workflows/.github/workflows/externalNut.yml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'windows-latest' ]
+    with:
+      packageName: '@salesforce/apex-node'
+      externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-apex'
+      command: 'yarn test:nuts'
+      os: ${{ matrix.os }}
+      preSwapCommands: 'yarn upgrade @salesforce/core; npx yarn-deduplicate; yarn install'
+      preExternalBuildCommands: 'npm why @salesforce/core --json'
+      useCache: false
+    secrets: inherit

--- a/.github/workflows/testCommitExceptMain.yml
+++ b/.github/workflows/testCommitExceptMain.yml
@@ -19,7 +19,6 @@ jobs:
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-apex'
       ignoreScripts: true
       os: ${{ matrix.os }}
-      branch: 'wr/bumpDeps'
       preSwapCommands: 'yarn upgrade @salesforce/core; npx yarn-deduplicate; yarn install'
       preExternalBuildCommands: 'npm why @salesforce/core --json'
       useCache: false

--- a/.github/workflows/testCommitExceptMain.yml
+++ b/.github/workflows/testCommitExceptMain.yml
@@ -17,7 +17,9 @@ jobs:
     with:
       packageName: '@salesforce/apex-node'
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-apex'
-      command: 'yarn test:nuts'
+      ignoreScripts: true
       os: ${{ matrix.os }}
+      preSwapCommands: 'yarn upgrade @salesforce/core; npx yarn-deduplicate; yarn install'
+      preExternalBuildCommands: 'npm why @salesforce/core --json'
       useCache: false
     secrets: inherit

--- a/.github/workflows/testCommitExceptMain.yml
+++ b/.github/workflows/testCommitExceptMain.yml
@@ -8,11 +8,12 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/unitTest.yml@main
   xNuts:
     needs: unit-tests
+    name: external NUTs
     uses: salesforcecli/github-workflows/.github/workflows/externalNut.yml@main
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: ['ubuntu-latest', 'windows-latest']
     with:
       packageName: '@salesforce/apex-node'
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-apex'

--- a/.github/workflows/testCommitExceptMain.yml
+++ b/.github/workflows/testCommitExceptMain.yml
@@ -19,6 +19,7 @@ jobs:
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-apex'
       ignoreScripts: true
       os: ${{ matrix.os }}
+      branch: 'wr/bumpDeps'
       preSwapCommands: 'yarn upgrade @salesforce/core; npx yarn-deduplicate; yarn install'
       preExternalBuildCommands: 'npm why @salesforce/core --json'
       useCache: false

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "lib/src/index.js",
   "dependencies": {
     "@jsforce/jsforce-node": "^3.1.0",
-    "@salesforce/core": "^7.2.0",
+    "@salesforce/core": "^7.3.1",
     "@salesforce/kit": "^3.1.0",
     "@types/istanbul-reports": "^3.0.4",
     "faye": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@jsforce/jsforce-node": "^3.1.0",
     "@salesforce/core": "^7.3.1",
-    "@salesforce/kit": "^3.1.0",
+    "@salesforce/kit": "^3.1.1",
     "@types/istanbul-reports": "^3.0.4",
     "faye": "1.4.0",
     "glob": "^10.3.10",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   ],
   "scripts": {
     "build": "shx rm -rf lib && tsc -b",
+    "compile": "shx rm -rf lib && tsc -b",
     "commit-init": "commitizen init cz-conventional-changelog --save-dev --save-exact --force",
     "commit": "git-cz",
     "format": "prettier --config ./.prettierrc --write './{src,test,scripts}/**/*.{ts,js,json}'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -569,14 +569,6 @@
     semver "^7.6.0"
     ts-retry-promise "^0.7.1"
 
-"@salesforce/kit@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.0.tgz#aa42533084c676e865f0f9c1907a16fb6f74dee7"
-  integrity sha512-X2d9O/U2wdQBXIrtVqQdMwo872Cv+qkYFzF0W+AQKG/LEe9cngnOzUVDYNkGD9tq3jcl+oenHXYuVDpkMhxTwA==
-  dependencies:
-    "@salesforce/ts-types" "^2.0.9"
-    tslib "^2.6.2"
-
 "@salesforce/kit@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.1.tgz#d2147a50887214763cdf1c456d306b6da554d928"

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,13 +546,13 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
-"@salesforce/core@^7.2.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.0.tgz#2ad3dfccb1ef0eb2e65b49b655e39748002bbc13"
-  integrity sha512-c/gZLvKFHvgAv/Gyd4LjGGQykvGLn67QtCmdT7Hnm57bTDZoyr7XJXcaI+ILN0NO47guG1tEWP5eBvAi+u2DNA==
+"@salesforce/core@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.1.tgz#cda324f7a5ff1be6d7381943b15b23dbe3cd5dec"
+  integrity sha512-jdc0GOUlV4xvyF9dPbBKNPDvQc06uj5YHFEHvdhCAFtCvqgtubpDzlyDppac2kdKujh4c7UH2KreboNvJ3LsoQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.1.0"
-    "@salesforce/kit" "^3.1.0"
+    "@salesforce/kit" "^3.1.1"
     "@salesforce/schemas" "^1.7.0"
     "@salesforce/ts-types" "^2.0.9"
     ajv "^8.12.0"
@@ -573,6 +573,14 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.0.tgz#aa42533084c676e865f0f9c1907a16fb6f74dee7"
   integrity sha512-X2d9O/U2wdQBXIrtVqQdMwo872Cv+qkYFzF0W+AQKG/LEe9cngnOzUVDYNkGD9tq3jcl+oenHXYuVDpkMhxTwA==
+  dependencies:
+    "@salesforce/ts-types" "^2.0.9"
+    tslib "^2.6.2"
+
+"@salesforce/kit@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.1.tgz#d2147a50887214763cdf1c456d306b6da554d928"
+  integrity sha512-Cjkh+USp5PtdZmD30r1Y7d+USpIhQz9B48w76esBtYpgqzhyj806LHkVgEfmorLNq2Qe8EO5rtUYd+XZ3rnV9w==
   dependencies:
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"


### PR DESCRIPTION
### What does this PR do?

sets up apex-node to run ext-NUTs on PRs

### What issues does this PR fix or reference?

@W-13748495@


### Functionality Before

no ext NUTs would run on library changes, breaking changes were possible

### Functionality After

external NUTs run before changes are merged and released in the library
