### PR TITLE
fix: All Apex classes/triggers in the ApexCodeCoverageAggregate table are displayed when the "Show Only Aggregated Code Coverage" setting is checked

### DIFF
--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -59,5 +59,5 @@ export const queryAll = async <R>(
     done: true,
     totalSize: allRecords.length,
     records: allRecords
-  } as QueryResult<R>;
+  };
 };

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -41,17 +41,17 @@ export async function queryNamespaces(
   return [...orgNamespaces, ...installedNamespaces];
 }
 
-export const queryAll = async <T>(
+export const queryAll = async <R>(
   connection: Connection,
   query: string,
   tooling = false
-): Promise<QueryResult<T>> => {
+): Promise<QueryResult<R>> => {
   const conn = tooling ? connection.tooling : connection;
-  const allRecords: T[] = [];
-  let result = await conn.query<T>(query);
+  const allRecords: R[] = [];
+  let result = await conn.query<R>(query);
   allRecords.push(...result.records);
   while (!result.done) {
-    result = (await conn.queryMore(result.nextRecordsUrl)) as QueryResult<T>;
+    result = (await conn.queryMore(result.nextRecordsUrl)) as QueryResult<R>;
     allRecords.push(...result.records);
   }
 
@@ -59,5 +59,5 @@ export const queryAll = async <T>(
     done: true,
     totalSize: allRecords.length,
     records: allRecords
-  } as QueryResult<T>;
+  } as QueryResult<R>;
 };

--- a/test/tests/codeCoverage.test.ts
+++ b/test/tests/codeCoverage.test.ts
@@ -147,15 +147,75 @@ describe('Get code coverage results', () => {
     expect(codeCoverageResults).to.eql(expectedResult);
   });
 
-  it('should return aggregate code coverage result with 0 records', async () => {
-    toolingQueryStub.throws('Error at Row:1;Column:1');
+  it('should return aggregate code coverage result with all records from AggregateCodeCoverage table', async () => {
+    const codeCoverageQueryResult = [
+      {
+        ApexClassOrTrigger: { Id: '0001x05958', Name: 'ApexTrigger1' },
+        NumLinesCovered: 5,
+        NumLinesUncovered: 1,
+        Coverage: { coveredLines: [1, 2, 3, 4, 5], uncoveredLines: [6] }
+      },
+      {
+        ApexClassOrTrigger: { Id: '0001x05959', Name: 'ApexTrigger2' },
+        NumLinesCovered: 6,
+        NumLinesUncovered: 2,
+        Coverage: { coveredLines: [1, 2, 3, 4, 5, 6], uncoveredLines: [7, 8] }
+      },
+      {
+        ApexClassOrTrigger: { Id: '0001x05951', Name: 'ApexTrigger3' },
+        NumLinesCovered: 7,
+        NumLinesUncovered: 3,
+        Coverage: {
+          coveredLines: [1, 2, 3, 4, 5, 6, 7],
+          uncoveredLines: [8, 9, 10]
+        }
+      }
+    ];
 
+    const expectedResult = [
+      {
+        apexId: '0001x05958',
+        coveredLines: [1, 2, 3, 4, 5],
+        name: 'ApexTrigger1',
+        numLinesCovered: 5,
+        numLinesUncovered: 1,
+        percentage: '83%',
+        type: 'ApexTrigger',
+        uncoveredLines: [6]
+      },
+      {
+        apexId: '0001x05959',
+        coveredLines: [1, 2, 3, 4, 5, 6],
+        name: 'ApexTrigger2',
+        numLinesCovered: 6,
+        numLinesUncovered: 2,
+        percentage: '75%',
+        type: 'ApexTrigger',
+        uncoveredLines: [7, 8]
+      },
+      {
+        apexId: '0001x05951',
+        coveredLines: [1, 2, 3, 4, 5, 6, 7],
+        name: 'ApexTrigger3',
+        numLinesCovered: 7,
+        numLinesUncovered: 3,
+        percentage: '70%',
+        type: 'ApexTrigger',
+        uncoveredLines: [8, 9, 10]
+      }
+    ];
+    toolingQueryStub.resolves({
+      done: true,
+      totalSize: 3,
+      records: codeCoverageQueryResult
+    } as ApexCodeCoverageAggregate);
     const codeCov = new CodeCoverage(mockConnection);
     const { codeCoverageResults, totalLines, coveredLines } =
-      await codeCov.getAggregateCodeCoverage(new Set([]));
-    expect(codeCoverageResults.length).to.equal(0);
-    expect(totalLines).to.equal(0);
-    expect(coveredLines).to.equal(0);
+      await codeCov.getAggregateCodeCoverage(new Set<string>());
+
+    expect(totalLines).to.equal(24);
+    expect(coveredLines).to.equal(18);
+    expect(codeCoverageResults).to.eql(expectedResult);
   });
 
   it('should return per class code coverage for multiple test classes', async () => {


### PR DESCRIPTION
### What does this PR do?
Populates the "Apex Code Coverage by Class" table in the Apex test results with all Apex classes/triggers listed in the ApexCodeCoverageAggregate Tooling API table when the "Show Only Aggregated Code Coverage" setting is checked.

### What issues does this PR fix or reference?

https://github.com/forcedotcom/salesforcedx-vscode/issues/5599, @W-15783639@

### Functionality Before
When the "Show Only Aggregated Code Coverage" setting is checked, the "Apex Code Coverage by Class" table in the Apex test results is empty.
```
=== Apex Code Coverage by Class
```

### Functionality After
When the "Show Only Aggregated Code Coverage" setting is checked, the "Apex Code Coverage by Class" table in the Apex test results is populated with all available Apex classes/triggers listed in the ApexCodeCoverageAggregate Tooling API table.
```
=== Apex Code Coverage by Class
CLASSES               PERCENT  UNCOVERED LINES
────────────────────  ───────  ───────────────
GeocodingService      100%                    
PagedResult           100%                    
PropertyController    100%                    
SampleDataController  100%                    
FileUtilities         100%   
```