### PR TITLE
feat: reformat human readable output for test results

### DIFF
--- a/src/reporters/humanFormatTransform.ts
+++ b/src/reporters/humanFormatTransform.ts
@@ -23,11 +23,13 @@ export class HumanFormatTransform extends Readable {
   constructor(
     private readonly testResult: TestResult,
     private readonly detailedCoverage: boolean,
+    private readonly concise: boolean,
     options?: ReadableOptions
   ) {
     super(options);
     this.testResult = testResult;
     this.detailedCoverage ??= false;
+    this.concise ??= false;
     this.logger = Logger.childFromRoot('HumanFormatTransform');
   }
 
@@ -135,17 +137,25 @@ export class HumanFormatTransform extends Readable {
         runTime: number;
         stackTrace: string | null;
       }) => {
-        const msg = elem.stackTrace
-          ? `${elem.message}\n${elem.stackTrace}`
-          : elem.message;
+        if (
+          !this.concise ||
+          elem.outcome === ApexTestResultOutcome.Fail ||
+          elem.outcome === ApexTestResultOutcome.CompileFail
+        ) {
+          const msg = elem.stackTrace
+            ? `${elem.message}\n${elem.stackTrace}`
+            : elem.message;
 
-        testRowArray.push({
-          name: elem.fullName,
-          outcome: elem.outcome,
-          msg: elem.message ? msg : '',
-          runtime:
-            elem.outcome !== ApexTestResultOutcome.Fail ? `${elem.runTime}` : ''
-        });
+          testRowArray.push({
+            name: elem.fullName,
+            outcome: elem.outcome,
+            msg: elem.message ? msg : '',
+            runtime:
+              elem.outcome !== ApexTestResultOutcome.Fail
+                ? `${elem.runTime}`
+                : ''
+          });
+        }
       }
     );
 

--- a/src/reporters/humanFormatTransform.ts
+++ b/src/reporters/humanFormatTransform.ts
@@ -47,7 +47,6 @@ export class HumanFormatTransform extends Readable {
 
   @elapsedTime()
   public format(): void {
-    this.formatSummary();
     if (!this.testResult.codecoverage || !this.detailedCoverage) {
       this.formatTestResults();
     }
@@ -58,6 +57,7 @@ export class HumanFormatTransform extends Readable {
       }
       this.formatCodeCov();
     }
+    this.formatSummary();
   }
 
   @elapsedTime()
@@ -112,6 +112,7 @@ export class HumanFormatTransform extends Readable {
         : [])
     ];
 
+    this.push(`${EOL}${EOL}`);
     tb.createTable(
       summaryRowArray,
       [

--- a/src/reporters/humanReporter.ts
+++ b/src/reporters/humanReporter.ts
@@ -227,7 +227,6 @@ export class HumanReporter {
   private formatCodeCov(codeCoverages: CodeCoverageResult[]): string {
     const tb = new Table();
     const codeCovRowArray: Row[] = [];
-    console.log('code_coverage');
     codeCoverages.forEach(
       (elem: {
         name: string;

--- a/src/reporters/humanReporter.ts
+++ b/src/reporters/humanReporter.ts
@@ -148,7 +148,7 @@ export class HumanReporter {
       }
     );
 
-    let testResultTable: string;
+    let testResultTable: string = '';
     if (testRowArray.length > 0) {
       testResultTable = os.EOL.repeat(2);
       testResultTable += tb.createTable(
@@ -206,7 +206,7 @@ export class HumanReporter {
       }
     });
 
-    let detailedCovTable: string;
+    let detailedCovTable: string = '';
     if (testRowArray.length > 0) {
       detailedCovTable = os.EOL.repeat(2);
       detailedCovTable += tb.createTable(

--- a/src/reporters/humanReporter.ts
+++ b/src/reporters/humanReporter.ts
@@ -21,7 +21,7 @@ export class HumanReporter {
   public format(testResult: TestResult, detailedCoverage: boolean): string {
     HeapMonitor.getInstance().checkHeapSize('HumanReporter.format');
     try {
-      let tbResult = this.formatSummary(testResult);
+      let tbResult: string;
       if (!testResult.codecoverage || !detailedCoverage) {
         tbResult += this.formatTestResults(testResult.tests);
       }
@@ -32,6 +32,7 @@ export class HumanReporter {
         }
         tbResult += this.formatCodeCov(testResult.codecoverage);
       }
+      tbResult += this.formatSummary(testResult);
       return tbResult;
     } finally {
       HeapMonitor.getInstance().checkHeapSize('HumanReporter.format');

--- a/src/reporters/humanReporter.ts
+++ b/src/reporters/humanReporter.ts
@@ -18,12 +18,16 @@ import * as os from 'node:os';
 
 export class HumanReporter {
   @elapsedTime()
-  public format(testResult: TestResult, detailedCoverage: boolean): string {
+  public format(
+    testResult: TestResult,
+    detailedCoverage: boolean,
+    verbose: boolean = true
+  ): string {
     HeapMonitor.getInstance().checkHeapSize('HumanReporter.format');
     try {
       let tbResult: string;
       if (!testResult.codecoverage || !detailedCoverage) {
-        tbResult += this.formatTestResults(testResult.tests);
+        tbResult += this.formatTestResults(testResult.tests, verbose);
       }
 
       if (testResult.codecoverage) {
@@ -105,7 +109,10 @@ export class HumanReporter {
   }
 
   @elapsedTime()
-  private formatTestResults(tests: ApexTestResultData[]): string {
+  private formatTestResults(
+    tests: ApexTestResultData[],
+    verbose: boolean
+  ): string {
     const tb = new Table();
     const testRowArray: Row[] = [];
     tests.forEach(
@@ -120,13 +127,21 @@ export class HumanReporter {
           ? `${elem.message}\n${elem.stackTrace}`
           : elem.message;
 
-        testRowArray.push({
-          name: elem.fullName,
-          outcome: elem.outcome,
-          msg: elem.message ? msg : '',
-          runtime:
-            elem.outcome !== ApexTestResultOutcome.Fail ? `${elem.runTime}` : ''
-        });
+        if (
+          verbose ||
+          elem.outcome === ApexTestResultOutcome.Fail ||
+          elem.outcome === ApexTestResultOutcome.CompileFail
+        ) {
+          testRowArray.push({
+            name: elem.fullName,
+            outcome: elem.outcome,
+            msg: elem.message ? msg : '',
+            runtime:
+              elem.outcome !== ApexTestResultOutcome.Fail
+                ? `${elem.runTime}`
+                : ''
+          });
+        }
       }
     );
 

--- a/src/reporters/humanReporter.ts
+++ b/src/reporters/humanReporter.ts
@@ -25,7 +25,7 @@ export class HumanReporter {
   ): string {
     HeapMonitor.getInstance().checkHeapSize('HumanReporter.format');
     try {
-      let tbResult: string;
+      let tbResult: string = '';
       if (!testResult.codecoverage || !detailedCoverage) {
         tbResult += this.formatTestResults(testResult.tests, concise);
       }

--- a/src/reporters/humanReporter.ts
+++ b/src/reporters/humanReporter.ts
@@ -21,13 +21,13 @@ export class HumanReporter {
   public format(
     testResult: TestResult,
     detailedCoverage: boolean,
-    verbose: boolean = true
+    concise: boolean = false
   ): string {
     HeapMonitor.getInstance().checkHeapSize('HumanReporter.format');
     try {
       let tbResult: string;
       if (!testResult.codecoverage || !detailedCoverage) {
-        tbResult += this.formatTestResults(testResult.tests, verbose);
+        tbResult += this.formatTestResults(testResult.tests, concise);
       }
 
       if (testResult.codecoverage) {
@@ -95,7 +95,8 @@ export class HumanReporter {
         : [])
     ];
 
-    return tb.createTable(
+    let summaryTable = os.EOL.repeat(2);
+    return (summaryTable += tb.createTable(
       summaryRowArray,
       [
         {
@@ -105,13 +106,13 @@ export class HumanReporter {
         { key: 'value', label: nls.localize('valueColHeader') }
       ],
       nls.localize('testSummaryHeader')
-    );
+    ));
   }
 
   @elapsedTime()
   private formatTestResults(
     tests: ApexTestResultData[],
-    verbose: boolean
+    concise: boolean
   ): string {
     const tb = new Table();
     const testRowArray: Row[] = [];
@@ -123,15 +124,15 @@ export class HumanReporter {
         runTime: number;
         stackTrace: string | null;
       }) => {
-        const msg = elem.stackTrace
-          ? `${elem.message}\n${elem.stackTrace}`
-          : elem.message;
-
         if (
-          verbose ||
+          !concise ||
           elem.outcome === ApexTestResultOutcome.Fail ||
           elem.outcome === ApexTestResultOutcome.CompileFail
         ) {
+          const msg = elem.stackTrace
+            ? `${elem.message}\n${elem.stackTrace}`
+            : elem.message;
+
           testRowArray.push({
             name: elem.fullName,
             outcome: elem.outcome,
@@ -226,6 +227,7 @@ export class HumanReporter {
   private formatCodeCov(codeCoverages: CodeCoverageResult[]): string {
     const tb = new Table();
     const codeCovRowArray: Row[] = [];
+    console.log('code_coverage');
     codeCoverages.forEach(
       (elem: {
         name: string;

--- a/test/reporters/humanFormatTransform.test.ts
+++ b/test/reporters/humanFormatTransform.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { HumanFormatTransform } from './../../src/reporters/humanFormatTransform';
+import { expect } from 'chai';
+import { pipeline, Writable } from 'node:stream';
+import {
+  testResults,
+  successResult,
+  coverageResult,
+  coverageFailResult
+} from './testResults';
+import { fail } from 'assert';
+
+describe('HumanFormatTransform', () => {
+  const createWritableAndPipeline = (
+    reporter: HumanFormatTransform,
+    callback: (result: string) => void
+  ): void => {
+    let result = '';
+
+    const writable = new Writable({
+      write(chunk, encoding, done) {
+        result += chunk;
+        done();
+      }
+    });
+
+    writable.on('finish', () => callback(result));
+
+    pipeline(reporter, writable, (err) => {
+      if (err) {
+        console.error('Pipeline failed', err);
+        fail(err);
+      }
+    });
+  };
+
+  it('should format test results with failures', () => {
+    const reporter = new HumanFormatTransform(testResults, false);
+    createWritableAndPipeline(reporter, (result) => {
+      expect(result).to.not.be.empty;
+      expect(result).to.contain(
+        'AnimalLocatorTest.testMissingAnimal                  Fail     System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual:'
+      );
+      expect(result).to.contain(
+        'Class.AnimalLocatorTest.testMissingAnimal: line 22, column 1'
+      );
+      expect(result).to.contain('=== Test Results');
+      expect(result).to.contain('=== Test Summary');
+    });
+  });
+
+  it('should format tests with 0 failures', () => {
+    const reporter = new HumanFormatTransform(successResult, false);
+    createWritableAndPipeline(reporter, (result) => {
+      expect(result).to.not.be.empty;
+      expect(result).to.contain(
+        'AccountServiceTest.should_create_account  Pass              86 '
+      );
+      expect(result).to.contain(
+        'AwesomeCalculatorTest.testCallout         Pass              23'
+      );
+      expect(result).to.contain('=== Test Results');
+      expect(result).to.contain('=== Test Summary');
+    });
+  });
+
+  it('should format test results with code coverage', async () => {
+    const reporter = new HumanFormatTransform(coverageResult, false);
+    createWritableAndPipeline(reporter, (result) => {
+      expect(result).to.not.be.empty;
+      expect(result).to.contain('=== Apex Code Coverage by Class');
+      expect(result).to.contain('ApexTestClass  12.5%    9,10');
+      expect(result).to.contain('=== Test Results');
+      expect(result).to.contain('=== Test Summary');
+    });
+  });
+
+  it('should format test results with detailed coverage specified', () => {
+    const reporter = new HumanFormatTransform(coverageResult, true);
+    createWritableAndPipeline(reporter, (result) => {
+      expect(result).to.not.be.empty;
+      expect(result).to.contain('=== Apex Code Coverage by Class');
+      expect(result).to.contain('ApexTestClass  12.5%    9,10');
+      expect(result).to.not.contain('=== Test Results');
+      expect(result).to.contain(
+        '=== Apex Code Coverage for Test Run 7073t000061uwZI'
+      );
+      expect(result).to.contain(
+        'AccountServiceTest.should_create_account                      Pass                       86'
+      );
+      expect(result).to.contain('=== Test Summary');
+    });
+  });
+
+  it('should format test results with failures with detailed coverage specified', () => {
+    const reporter = new HumanFormatTransform(coverageFailResult, true);
+    createWritableAndPipeline(reporter, (result) => {
+      expect(result).to.not.be.empty;
+      expect(result).to.contain('=== Apex Code Coverage by Class');
+      expect(result).to.contain('ApexTestClass  12.5%    9,10');
+      expect(result).to.not.contain('=== Test Results');
+      expect(result).to.contain(
+        '=== Apex Code Coverage for Test Run 7073t000061uwZI'
+      );
+      expect(result).to.contain(
+        'AccountServiceTest.should_create_account                      Pass                                                                                                                    86'
+      );
+      expect(result).to.contain(
+        'AnimalLocatorTest.testMissingAnimal                           Fail              System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual'
+      );
+      expect(result).to.contain(
+        'Class.AnimalLocatorTest.testMissingAnimal: line 22, column 1'
+      );
+      expect(result).to.contain('=== Test Summary');
+    });
+  });
+
+  it('should format test results and skip successful tests if concise is true', () => {
+    const reporter = new HumanFormatTransform(testResults, false, true);
+    createWritableAndPipeline(reporter, (result) => {
+      expect(result).to.not.be.empty;
+      expect(result).to.not.contain(
+        'AccountServiceTest.should_create_account             Pass                                                                                                           86'
+      );
+      expect(result).to.contain('AwesomeCalculatorTest.testCallout       Fail');
+      expect(result).to.contain('=== Test Results');
+      expect(result).to.contain('=== Test Summary');
+    });
+  });
+
+  it('should format test results and not display coverage results if concise is true', () => {
+    const reporter = new HumanFormatTransform(coverageFailResult, true, true);
+    createWritableAndPipeline(reporter, (result) => {
+      expect(result).to.not.be.empty;
+      expect(result).to.not.contain('=== Apex Code Coverage by Class');
+      expect(result).to.not.contain('ApexTestClass  12.5%    9,10');
+      expect(result).to.contain(
+        '=== Apex Code Coverage for Test Run 7073t000061uwZI'
+      );
+      expect(result).to.not.contain(
+        'AccountServiceTest.should_create_account             Pass                                                                                                           86'
+      );
+      expect(result).to.contain(
+        'AnimalLocatorTest.testMissingAnimal                      Fail              System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual:'
+      );
+      expect(result).to.contain('=== Test Summary');
+    });
+  });
+});

--- a/test/reporters/humanReporter.test.ts
+++ b/test/reporters/humanReporter.test.ts
@@ -97,4 +97,21 @@ describe('Human Reporter Tests', () => {
     expect(result).to.contain('=== Test Results');
     expect(result).to.contain('=== Test Summary');
   });
+
+  it('should format test results and not display coverage results if concise is true', () => {
+    const result = reporter.format(coverageFailResult, true, true);
+    expect(result).to.not.be.empty;
+    expect(result).to.not.contain('=== Apex Code Coverage by Class');
+    expect(result).to.not.contain('ApexTestClass  12.5%    9,10');
+    expect(result).to.contain(
+      '=== Apex Code Coverage for Test Run 7073t000061uwZI'
+    );
+    expect(result).to.not.contain(
+      'AccountServiceTest.should_create_account             Pass                                                                                                           86'
+    );
+    expect(result).to.contain(
+      'AnimalLocatorTest.testMissingAnimal                      Fail              System.AssertException: Assertion Failed: Should not have found an animal: Expected: FooBar, Actual:'
+    );
+    expect(result).to.contain('=== Test Summary');
+  });
 });

--- a/test/reporters/humanReporter.test.ts
+++ b/test/reporters/humanReporter.test.ts
@@ -87,8 +87,8 @@ describe('Human Reporter Tests', () => {
     expect(result).to.contain('=== Test Summary');
   });
 
-  it('should format test results and skip successful tests if verbose is false', () => {
-    const result = reporter.format(testResults, false, false);
+  it('should format test results and skip successful tests if concise is true', () => {
+    const result = reporter.format(testResults, false, true);
     expect(result).to.not.be.empty;
     expect(result).to.not.contain(
       'AccountServiceTest.should_create_account             Pass                                                                                                           86'

--- a/test/reporters/humanReporter.test.ts
+++ b/test/reporters/humanReporter.test.ts
@@ -86,4 +86,15 @@ describe('Human Reporter Tests', () => {
     );
     expect(result).to.contain('=== Test Summary');
   });
+
+  it('should format test results and skip successful tests if verbose is false', () => {
+    const result = reporter.format(testResults, false, false);
+    expect(result).to.not.be.empty;
+    expect(result).to.not.contain(
+      'AccountServiceTest.should_create_account             Pass                                                                                                           86'
+    );
+    expect(result).to.contain('AwesomeCalculatorTest.testCallout       Fail');
+    expect(result).to.contain('=== Test Results');
+    expect(result).to.contain('=== Test Summary');
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Adds a ~~`verbose`~~ `concise` parameter to the HumanReporter format function. If true, then display all test results (current behavior). If false, only display failing tests. I have left the default value as ~~`true`~~ `false` to preserve existing behavior, with the plan to add a ~~`--verbose`~~ `--concise` flag to the `sf apex run test` command to control this behavior.

I have also moved the summary section for test results to the bottom of the output. This makes it much easier to tell at a glance whether your tests ran successfully or not. Even with the removal of passing tests in the output, it can still be cumbersome to scroll through the results to see the summary.

I primarily have the sf cli in mind but I don't know if this is used anywhere else or if there are other considerations I'm unaware of.

### What issues does this PR fix or reference?
- https://github.com/forcedotcom/cli/discussions/2872
- https://github.com/forcedotcom/salesforcedx-apex/issues/243

### Functionality Before
Before, the summary was at the top of the terminal output and it displayed the results of ALL test methods, which required users to scroll a lot.

### Functionality After
Now, the summary is at the bottom and can optionally only display failing tests, making it easier to see when read by a human.
