### PR TITLE
W-19127872: Remove hrtime

### DIFF
--- a/src/utils/elapsedTime.ts
+++ b/src/utils/elapsedTime.ts
@@ -62,7 +62,7 @@ export function elapsedTime(
     const className = target.constructor.name;
     descriptor.value = function (...args: any[]) {
       const logger = Logger.childFromRoot(loggerName);
-      const start = process.hrtime();
+      const start = globalThis.performance.now();
 
       log(level, logger, `${className}.${propertyKey} - enter`);
 
@@ -76,8 +76,7 @@ export function elapsedTime(
       }
 
       const handleResult = () => {
-        const diff = process.hrtime(start);
-        const elapsedTime = diff[0] * 1e3 + diff[1] / 1e6;
+        const elapsedTime = globalThis.performance.now() - start;
         log(level, logger, `${className}.${propertyKey} - exit`, {
           elapsedTime
         });

--- a/test/tests/elapsedTime.test.ts
+++ b/test/tests/elapsedTime.test.ts
@@ -41,13 +41,13 @@ class RejectingTestClassWithPromise {
 }
 
 describe('elapsedTime', () => {
-  let hrtimeStub: sinon.SinonStub;
+  let performanceNowStub: sinon.SinonStub;
   let loggerStub: sinon.SinonStubbedInstance<Logger>;
 
   beforeEach(() => {
-    hrtimeStub = sinon.stub(process, 'hrtime');
-    hrtimeStub.onCall(0).returns([0, 0]);
-    hrtimeStub.onCall(1).returns([1, 0]);
+    performanceNowStub = sinon.stub(globalThis.performance, 'now');
+    performanceNowStub.onCall(0).returns(0);
+    performanceNowStub.onCall(1).returns(1000);
     loggerStub = sinon.createStubInstance(Logger);
     sinon
       .stub(Logger, 'childFromRoot')


### PR DESCRIPTION
### What does this PR do?
Replaces process.hrtime() calls with globalThis.performance.now() 

### What issues does this PR fix or reference?
@W-19127872@

### Functionality Before
hrtime usage 1

### Functionality After
hrtime usage 0
