### PR TITLE
fix: configure automerge package manager

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,4 +7,7 @@ on:
 jobs:
   automerge:
     uses: salesforcecli/github-workflows/.github/workflows/automerge.yml@main
+    with:
+      package-manager: yarn
+      cache-dependency-path: yarn.lock
     secrets: inherit


### PR DESCRIPTION
## Summary

- configure the shared automerge workflow to use Yarn
- point dependency caching at `yarn.lock`
- avoid the upstream npm/`package-lock.json` defaults that caused scheduled automerge runs to fail

## Validation

- `node_modules/.bin/prettier --check .github/workflows/automerge.yml`
- `git diff --check`